### PR TITLE
LA updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 cadvisor
+.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     - build-essential
     - curl
 script:
+- BUILD_HOME="$TRAVIS_BUILD_DIR" ./install.sh
 - BUILD_HOME="$TRAVIS_BUILD_DIR" DEPLOY_TO="$TRAVIS_BUILD_DIR/deploy/$TRAVIS_REPO_SLUG/$TRAVIS_BRANCH" ./build.sh
 deploy:
   skip_cleanup: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,16 @@ ENV DEPLOY_TO "/home/${BUILD_USER}/out"
 
 RUN useradd "$BUILD_USER"
 
-ADD . "$BUILD_HOME"
+RUN mkdir "$BUILD_HOME"
 RUN chown -R "$BUILD_USER" "$BUILD_HOME"
 
 USER "$BUILD_USER"
 WORKDIR "$BUILD_HOME"
+
+ADD helper.inc "$BUILD_HOME"
+ADD install.sh "$BUILD_HOME"
+
+RUN "${BUILD_HOME}/install.sh"
+ADD . "$BUILD_HOME"
 
 CMD "${BUILD_HOME}/build.sh"

--- a/build.sh
+++ b/build.sh
@@ -6,34 +6,11 @@ set -o nounset
 # - BUILD_HOME
 # - DEPLOY_TO
 
-CADVISOR_BASE_VERSION="v0.22.2"
-
-GODIST="${BUILD_HOME}/godist"
-export GOROOT="${GODIST}/go"
-export GOPATH="${BUILD_HOME}/gopath"
-export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
-
-GOLANG_VERSION=1.6
-GOLANG_DOWNLOAD_URL="https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"
-GOLANG_DOWNLOAD_SHA256="5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b"
-GO_DEPS=(github.com/tools/godep)
-
-curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz
-echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c -
-
-mkdir -p "$GODIST"
-tar -C "$GODIST" -xzf golang.tar.gz
-rm golang.tar.gz
-
-# Get Go build dependencies
-go get "${GO_DEPS[@]}"
-
-# Get cadvisor
-CADVISOR="github.com/google/cadvisor"
-go get -d "$CADVISOR" || true  # Usually an error about an expected import that doesn't matter..!
-cd "${GOPATH}/src/${CADVISOR}"
+# shellcheck source=helper.inc
+. "${BUILD_HOME}/helper.inc"
 
 # Check out what we're building, and apply our patch series
+cd "${GOPATH}/src/${CADVISOR}"
 git checkout "$CADVISOR_BASE_VERSION"
 
 for patchfile in "${BUILD_HOME}/patches/"*.patch; do

--- a/helper.inc
+++ b/helper.inc
@@ -1,0 +1,9 @@
+#!/bin/bash
+export GODIST="${BUILD_HOME}/godist"
+export GOROOT="${GODIST}/go"
+export GOPATH="${BUILD_HOME}/gopath"
+
+export PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
+
+export CADVISOR="github.com/google/cadvisor"
+export CADVISOR_BASE_VERSION="v0.22.2"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+# shellcheck source=helper.inc
+. "${BUILD_HOME}/helper.inc"
+
+GOLANG_VERSION=1.6
+GOLANG_DOWNLOAD_URL="https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz"
+GOLANG_DOWNLOAD_SHA256="5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b"
+GO_DEPS=(github.com/tools/godep)
+
+curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz
+echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c -
+
+mkdir -p "$GODIST"
+tar -C "$GODIST" -xzf golang.tar.gz
+rm golang.tar.gz
+
+# Get Go build dependencies
+go get "${GO_DEPS[@]}"
+
+# Get cadvisor
+go get -d "$CADVISOR" || true  # Usually an error about an expected import that doesn't matter..!

--- a/patches/0006-Include-uninterruptible-and-IO-wait-tasks-in-LA.patch
+++ b/patches/0006-Include-uninterruptible-and-IO-wait-tasks-in-LA.patch
@@ -1,0 +1,26 @@
+From 7e6ffc1da098b206040c7d4ef3507a96ea743e8d Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Mon, 4 Apr 2016 17:56:53 +0200
+Subject: [PATCH 1/1] Include uninterruptible and IO wait tasks in LA
+
+Otherwise, the load average doesn't report tasks stuck on IO (which is
+counter-intuitive to the concept of the load average).
+---
+ manager/container.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index baae002..dffd50f 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -527,7 +527,7 @@ func (c *containerData) updateStats() error {
+ 				return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
+ 			}
+ 			stats.TaskStats = loadStats
+-			c.updateLoad(loadStats.NrRunning)
++			c.updateLoad(loadStats.NrRunning + loadStats.NrUninterruptible + loadStats.NrIoWait)
+ 			// convert to 'milliLoad' to avoid floats and preserve precision.
+ 			stats.Cpu.LoadAverage = int32(c.loadAvg * 1000)
+ 		}
+-- 
+1.9.1

--- a/patches/0007-Probe-LA-independent-of-housekeeping-interval.patch
+++ b/patches/0007-Probe-LA-independent-of-housekeeping-interval.patch
@@ -1,0 +1,253 @@
+From e6bf3fb3a2b1aac0b74493589a555cb4797a62a6 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Mon, 4 Apr 2016 17:59:38 +0200
+Subject: [PATCH] Probe LA independent of housekeeping interval
+
+Load Average is a metric that inherently relies on being probed for
+frequently (otherwise, it ends up being dependent on the luck of the
+draw more so than on the actual value). This updates the container
+manager to run the LA probe on a different schedule from the regular
+housekeeping, and uses the last observed value when reporting.
+---
+ manager/container.go | 126 ++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 100 insertions(+), 26 deletions(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index dffd50f..7dce924 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -45,6 +45,7 @@ import (
+ 
+ // Housekeeping interval.
+ var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
++var LoadreaderInterval = flag.Duration("load_reader_interval", 1*time.Second, "Interval between load reader probes")
+ 
+ var cgroupPathRegExp = regexp.MustCompile(`devices[^:]*:(.*?)[,;$]`)
+ 
+@@ -61,15 +62,23 @@ type containerData struct {
+ 	lock                     sync.Mutex
+ 	loadReader               cpuload.CpuLoadReader
+ 	summaryReader            *summary.StatsSummary
+-	loadAvg                  float64 // smoothed load average seen so far.
+ 	housekeepingInterval     time.Duration
+ 	maxHousekeepingInterval  time.Duration
+ 	allowDynamicHousekeeping bool
+ 	lastUpdatedTime          time.Time
+ 	lastErrorTime            time.Time
+ 
++	// smoothed load average seen so far.
++	loadAvg                  float64
++	// How often load average should be checked (samples are unreliable by nature)
++	loadreaderInterval       time.Duration
+ 	// Decay value used for load average smoothing. Interval length of 10 seconds is used.
+-	loadDecay float64
++	loadDecay                float64
++	loadStop                 chan bool
++	loadLock                 sync.Mutex
++
++	// last taskstats
++	taskStats                info.LoadStats
+ 
+ 	// Whether to log the usage of this container when it is updated.
+ 	logUsage bool
+@@ -93,7 +102,8 @@ func jitter(duration time.Duration, maxFactor float64) time.Duration {
+ }
+ 
+ func (c *containerData) Start() error {
+-	go c.housekeeping()
++	go c.doHousekeepingLoop()
++	go c.doLoadReaderLoop()
+ 	return nil
+ }
+ 
+@@ -103,6 +113,7 @@ func (c *containerData) Stop() error {
+ 		return err
+ 	}
+ 	c.stop <- true
++	c.loadStop <- true
+ 	return nil
+ }
+ 
+@@ -326,13 +337,14 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ 		loadReader:               loadReader,
+ 		logUsage:                 logUsage,
+ 		loadAvg:                  -1.0, // negative value indicates uninitialized.
++		loadreaderInterval:       *LoadreaderInterval,
++		loadDecay:                math.Exp(float64(-(*LoadreaderInterval).Seconds() / 10)),
++		loadStop:                 make(chan bool, 1),
+ 		stop:                     make(chan bool, 1),
+ 		collectorManager:         collectorManager,
+ 	}
+ 	cont.info.ContainerReference = ref
+ 
+-	cont.loadDecay = math.Exp(float64(-cont.housekeepingInterval.Seconds() / 10))
+-
+ 	err = cont.updateSpec()
+ 	if err != nil {
+ 		return nil, err
+@@ -374,7 +386,7 @@ func (self *containerData) nextHousekeeping(lastHousekeeping time.Time) time.Tim
+ }
+ 
+ // TODO(vmarmol): Implement stats collecting as a custom collector.
+-func (c *containerData) housekeeping() {
++func (c *containerData) doHousekeepingLoop() {
+ 	// Start any background goroutines - must be cleaned up in c.handler.Cleanup().
+ 	c.handler.Start()
+ 
+@@ -384,7 +396,6 @@ func (c *containerData) housekeeping() {
+ 		longHousekeeping = *HousekeepingInterval / 2
+ 	}
+ 
+-	// Housekeep every second.
+ 	glog.V(3).Infof("Start housekeeping for container %q\n", c.info.Name)
+ 	lastHousekeeping := time.Now()
+ 	for {
+@@ -397,7 +408,7 @@ func (c *containerData) housekeeping() {
+ 		default:
+ 			// Perform housekeeping.
+ 			start := time.Now()
+-			c.housekeepingTick()
++			c.doWithTimeout((*containerData).updateStats, (*HousekeepingInterval)*2)
+ 
+ 			// Log if housekeeping took too long.
+ 			duration := time.Since(start)
+@@ -445,11 +456,13 @@ func (c *containerData) housekeeping() {
+ 	}
+ }
+ 
+-func (c *containerData) housekeepingTick() {
++type ContainerDataMethod func(c *containerData) error;
++
++func (c *containerData) doWithTimeout(meth ContainerDataMethod, timeout time.Duration) {
+ 	done := make(chan bool, 1)
+ 
+ 	go func() {
+-		err := c.updateStats()
++		err := meth(c)
+ 		if err != nil {
+ 			if c.allowErrorLogging() {
+ 				glog.Infof("Failed to update stats for container \"%s\": %s", c.info.Name, err)
+@@ -461,9 +474,9 @@ func (c *containerData) housekeepingTick() {
+ 	select {
+ 	case <-done:
+ 		// Nothing to do
+-	case <-time.After(*HousekeepingInterval * 2):
++	case <-time.After(timeout):
+ 		// We timed out. Dump all goroutine stacks to facilitate troubleshooting, and panic.
+-		glog.Errorf("Housekeeping timed out for container %s", c.info.Name)
++		glog.Errorf("Timed out for: %s", c.info.Name)
+ 		pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+ 		panic("Aborting!")
+ 	}
+@@ -496,7 +509,10 @@ func (c *containerData) updateSpec() error {
+ // Calculate new smoothed load average using the new sample of runnable threads.
+ // The decay used ensures that the load will stabilize on a new constant value within
+ // 10 seconds.
+-func (c *containerData) updateLoad(newLoad uint64) {
++func (c *containerData) updateLoadAvg(newLoad uint64) {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
+ 	if c.loadAvg < 0 {
+ 		c.loadAvg = float64(newLoad) // initialize to the first seen sample for faster stabilization.
+ 	} else {
+@@ -504,6 +520,69 @@ func (c *containerData) updateLoad(newLoad uint64) {
+ 	}
+ }
+ 
++func (c *containerData) LoadAvg() float64 {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	return c.loadAvg;
++}
++
++func (c *containerData) updateTaskStats(taskStats info.LoadStats) {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	c.taskStats = taskStats
++}
++
++func (c *containerData) TaskStats() info.LoadStats {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	return c.taskStats;
++}
++
++func (c *containerData) doLoadReaderIteration() error {
++	path, err := c.handler.GetCgroupPath("cpu")
++	if err == nil {
++		taskStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
++		if err != nil {
++			return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
++		}
++		c.updateLoadAvg(taskStats.NrRunning + taskStats.NrUninterruptible + taskStats.NrIoWait)
++		c.updateTaskStats(taskStats)
++	}
++
++	return nil;
++}
++
++func (c *containerData) doLoadReaderLoop() {
++	if c.loadReader == nil {
++		// Load reader is disabled. Don't even start the loop.
++		return
++	}
++
++	lastIteration := time.Now()
++	for {
++		select {
++		case <-c.loadStop:
++			return
++		default:
++			c.doWithTimeout((*containerData).doLoadReaderIteration, (c.loadreaderInterval)*2)
++		}
++
++		// Schedule the next housekeeping. Sleep until that time.
++		next := lastIteration.Add(c.loadreaderInterval)
++
++		if time.Now().Before(next) {
++			time.Sleep(next.Sub(time.Now()))
++		} else {
++			next = time.Now()
++		}
++
++		lastIteration = next
++	}
++}
++
+ func (c *containerData) updateStats() error {
+ 	stats, statsErr := c.handler.GetStats()
+ 	if statsErr != nil {
+@@ -518,19 +597,14 @@ func (c *containerData) updateStats() error {
+ 	if stats == nil {
+ 		return statsErr
+ 	}
+-	if c.loadReader != nil {
+-		// TODO(vmarmol): Cache this path.
+-		path, err := c.handler.GetCgroupPath("cpu")
+-		if err == nil {
+-			loadStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
+-			if err != nil {
+-				return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
+-			}
+-			stats.TaskStats = loadStats
+-			c.updateLoad(loadStats.NrRunning + loadStats.NrUninterruptible + loadStats.NrIoWait)
+-			// convert to 'milliLoad' to avoid floats and preserve precision.
+-			stats.Cpu.LoadAverage = int32(c.loadAvg * 1000)
+-		}
++	load := c.LoadAvg()
++	if load >= 0 {
++		// convert to 'milliLoad' to avoid floats and preserve precision.
++		stats.Cpu.LoadAverage = int32(load * 1000)
++	}
++	taskStats := c.TaskStats()
++	if &taskStats != nil {
++		stats.TaskStats = taskStats
+ 	}
+ 	if c.summaryReader != nil {
+ 		err := c.summaryReader.AddSample(*stats)
+-- 
+1.9.1


### PR DESCRIPTION
This should make load average reporting a load more reliable and meaningful:

- Include uninterruptible and io wait tasks in LA.
- Probe for LA at a higher frequency (every second by default), which
  minimizes the impact of when exactly we probe for it.


cc @fancyremarker 