### PR TITLE
Patch set updates:

### DIFF
--- a/patches/0001-Add-container_id-as-tag.patch
+++ b/patches/0001-Add-container_id-as-tag.patch
@@ -1,7 +1,7 @@
-From a5f822cabb0932beaa772dc9a1e622e390ba38cf Mon Sep 17 00:00:00 2001
+From 7a55128955105f3a8755a9abf1c384e7be9fc925 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
-Date: Fri, 18 Mar 2016 19:48:04 +0100
-Subject: [PATCH 1/1] Add container_id as tag
+Date: Mon, 4 Apr 2016 21:31:01 +0200
+Subject: [PATCH 1/7] Add container_id as tag
 
 Dereferenced aliases can be nice, but a predictable container ID is nice
 too.
@@ -31,3 +31,4 @@ index 82739b5..4aeb89d 100644
  		// merge with existing tags if any
 -- 
 1.9.1
+

--- a/patches/0002-Panic-and-dump-stacks-on-housekeeping-time-out.patch
+++ b/patches/0002-Panic-and-dump-stacks-on-housekeeping-time-out.patch
@@ -1,7 +1,7 @@
-From 00d2779f8899a27a8e7a5e1f294e14d3b99cc66e Mon Sep 17 00:00:00 2001
+From 18d4b36a15c9dd3137e71b7eb3e31f80f6797b25 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Fri, 1 Apr 2016 11:23:38 +0200
-Subject: [PATCH 1/1] Panic and dump stacks on housekeeping time out
+Subject: [PATCH 2/7] Panic and dump stacks on housekeeping time out
 
 We'd rather have a process manager restart the entire cAdvisor process
 rather than stop reporting altogether for a given container (which is
@@ -56,3 +56,4 @@ index b1d8d33..baae002 100644
  
 -- 
 1.9.1
+

--- a/patches/0003-Add-support-for-UNIX-sockets.patch
+++ b/patches/0003-Add-support-for-UNIX-sockets.patch
@@ -1,3 +1,12 @@
+From b0b131b72ee9f5489a187714e464856dfa927beb Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Wed, 30 Mar 2016 10:17:58 +0200
+Subject: [PATCH 3/7] Add support for UNIX sockets
+
+---
+ cadvisor.go | 41 +++++++++++++++++++++++++++++++++++------
+ 1 file changed, 35 insertions(+), 6 deletions(-)
+
 diff --git a/cadvisor.go b/cadvisor.go
 index 6f6a0ad..5cd4f89 100644
 --- a/cadvisor.go
@@ -82,3 +91,6 @@ index 6f6a0ad..5cd4f89 100644
  		glog.Infof("Exiting given signal: %v", sig)
  		os.Exit(0)
  	}()
+-- 
+1.9.1
+

--- a/patches/0004-Don-t-allocate-4GB-of-memory-on-netlink-conn.patch
+++ b/patches/0004-Don-t-allocate-4GB-of-memory-on-netlink-conn.patch
@@ -1,27 +1,39 @@
+From 3d064720a27e6ec14f5b282eacfd3a62867e02c8 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Thu, 31 Mar 2016 23:36:08 +0200
+Subject: [PATCH 4/7] Don't allocate 4GB of memory on netlink conn
+
+---
+ utils/cpuload/netlink/conn.go    |  8 ++++++++
+ utils/cpuload/netlink/defs.go    | 14 +++++++++++---
+ utils/cpuload/netlink/netlink.go | 20 +++++---------------
+ 3 files changed, 24 insertions(+), 18 deletions(-)
+
 diff --git a/utils/cpuload/netlink/conn.go b/utils/cpuload/netlink/conn.go
-index 7eb2204..5b1a58f 100644
+index 7eb2204..cd7cc4e 100644
 --- a/utils/cpuload/netlink/conn.go
 +++ b/utils/cpuload/netlink/conn.go
-@@ -20,6 +20,9 @@ import (
+@@ -18,8 +18,11 @@ import (
+ 	"bufio"
+ 	"bytes"
  	"encoding/binary"
++	"errors"
  	"os"
  	"syscall"
-+	"errors"
 +
 +	"github.com/golang/glog"
  )
  
  type Connection struct {
-@@ -52,6 +55,8 @@ func newConnection() (*Connection, error) {
+@@ -52,6 +55,7 @@ func newConnection() (*Connection, error) {
  		syscall.Close(fd)
  		return nil, err
  	}
-+
 +	glog.V(4).Infof("New Netlink connection: %+v", conn)
  	return conn, err
  }
  
-@@ -89,6 +94,10 @@ func (self *Connection) ReadMessage() (msg syscall.NetlinkMessage, err error) {
+@@ -89,6 +93,10 @@ func (self *Connection) ReadMessage() (msg syscall.NetlinkMessage, err error) {
  	if err != nil {
  		return msg, err
  	}
@@ -33,7 +45,7 @@ index 7eb2204..5b1a58f 100644
  	_, err = self.rbuf.Read(msg.Data)
  	return msg, err
 diff --git a/utils/cpuload/netlink/defs.go b/utils/cpuload/netlink/defs.go
-index a45d870..cdb5517 100644
+index a45d870..0a6c7d0 100644
 --- a/utils/cpuload/netlink/defs.go
 +++ b/utils/cpuload/netlink/defs.go
 @@ -15,12 +15,20 @@
@@ -50,14 +62,14 @@ index a45d870..cdb5517 100644
 -
  const (
 -	__TASKSTATS_CMD_MAX = C.__TASKSTATS_CMD_MAX
-+	GENL_ID_CTRL = C.GENL_ID_CTRL
-+	CTRL_ATTR_FAMILY_ID = C.CTRL_ATTR_FAMILY_ID
-+	CTRL_ATTR_FAMILY_NAME = C.CTRL_ATTR_FAMILY_NAME
-+	CTRL_CMD_GETFAMILY = C.CTRL_CMD_GETFAMILY
-+	TASKSTATS_GENL_NAME = C.TASKSTATS_GENL_NAME
-+	TASKSTATS_GENL_VERSION = C.TASKSTATS_GENL_VERSION
-+	CGROUPSTATS_CMD_GET = C.CGROUPSTATS_CMD_GET
-+	CGROUPSTATS_CMD_ATTR_FD = C.CGROUPSTATS_CMD_ATTR_FD
++	GENL_ID_CTRL                  = C.GENL_ID_CTRL
++	CTRL_ATTR_FAMILY_ID           = C.CTRL_ATTR_FAMILY_ID
++	CTRL_ATTR_FAMILY_NAME         = C.CTRL_ATTR_FAMILY_NAME
++	CTRL_CMD_GETFAMILY            = C.CTRL_CMD_GETFAMILY
++	TASKSTATS_GENL_NAME           = C.TASKSTATS_GENL_NAME
++	TASKSTATS_GENL_VERSION        = C.TASKSTATS_GENL_VERSION
++	CGROUPSTATS_CMD_GET           = C.CGROUPSTATS_CMD_GET
++	CGROUPSTATS_CMD_ATTR_FD       = C.CGROUPSTATS_CMD_ATTR_FD
 +	CGROUPSTATS_TYPE_CGROUP_STATS = C.CGROUPSTATS_TYPE_CGROUP_STATS
  )
 diff --git a/utils/cpuload/netlink/netlink.go b/utils/cpuload/netlink/netlink.go
@@ -110,53 +122,6 @@ index 7ca05f3..accf294 100644
  			err = binary.Read(buf, Endian, &id)
  			if err != nil {
  				return 0, err
-diff --git a/utils/cpuload/netlink/reader.go b/utils/cpuload/netlink/reader.go
-index 4e3aa68..9ed93f9 100644
---- a/utils/cpuload/netlink/reader.go
-+++ b/utils/cpuload/netlink/reader.go
-@@ -25,7 +25,6 @@ import (
- 
- type NetlinkReader struct {
- 	familyId uint16
--	conn     *Connection
- }
- 
- func New() (*NetlinkReader, error) {
-@@ -33,6 +32,7 @@ func New() (*NetlinkReader, error) {
- 	if err != nil {
- 		return nil, fmt.Errorf("failed to create a new connection: %s", err)
- 	}
-+	defer conn.Close()
- 
- 	id, err := getFamilyId(conn)
- 	if err != nil {
-@@ -41,14 +41,10 @@ func New() (*NetlinkReader, error) {
- 	glog.V(4).Infof("Family id for taskstats: %d", id)
- 	return &NetlinkReader{
- 		familyId: id,
--		conn:     conn,
- 	}, nil
- }
- 
- func (self *NetlinkReader) Stop() {
--	if self.conn != nil {
--		self.conn.Close()
--	}
- }
- 
- func (self *NetlinkReader) Start() error {
-@@ -70,7 +66,13 @@ func (self *NetlinkReader) GetCpuLoad(name string, path string) (info.LoadStats,
- 		return info.LoadStats{}, fmt.Errorf("failed to open cgroup path %s: %q", path, err)
- 	}
- 
--	stats, err := getLoadStats(self.familyId, cfd.Fd(), self.conn)
-+	conn, err := newConnection()
-+	if err != nil {
-+		return info.LoadStats{}, fmt.Errorf("failed to create a new connection: %s", err)
-+	}
-+	defer conn.Close()
-+
-+	stats, err := getLoadStats(self.familyId, cfd.Fd(), conn)
- 	if err != nil {
- 		return info.LoadStats{}, err
- 	}
+-- 
+1.9.1
+

--- a/patches/0005-Account-for-Memory-RSS.patch
+++ b/patches/0005-Account-for-Memory-RSS.patch
@@ -1,7 +1,7 @@
-From 59f278fe9965a98a87dc18479000f3af4ce88536 Mon Sep 17 00:00:00 2001
+From 470af9c7088587eee26272c0117169a073c12e98 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Fri, 1 Apr 2016 10:38:12 +0200
-Subject: [PATCH 1/1] Account for Memory RSS
+Subject: [PATCH 5/7] Account for Memory RSS
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -55,7 +55,7 @@ index bcf2658..e3d3a09 100644
  		ret.Memory.ContainerData.Pgfault = v
  		ret.Memory.HierarchicalData.Pgfault = v
 diff --git a/storage/influxdb/influxdb.go b/storage/influxdb/influxdb.go
-index 82739b5..796be46 100644
+index 4aeb89d..5e80e9f 100644
 --- a/storage/influxdb/influxdb.go
 +++ b/storage/influxdb/influxdb.go
 @@ -55,6 +55,8 @@ const (
@@ -67,7 +67,7 @@ index 82739b5..796be46 100644
  	// Working set size
  	serMemoryWorkingSet string = "memory_working_set"
  	// Cumulative count of bytes received.
-@@ -194,8 +196,8 @@ func (self *influxdbStorage) containerStatsToPoints(
+@@ -196,8 +198,8 @@ func (self *influxdbStorage) containerStatsToPoints(
  	// Memory Usage
  	points = append(points, makePoint(serMemoryUsage, stats.Memory.Usage))
  
@@ -103,3 +103,4 @@ index aa8aafe..6c4e8e3 100644
  
 -- 
 1.9.1
+

--- a/patches/0006-Include-uninterruptible-and-IO-wait-tasks-in-LA.patch
+++ b/patches/0006-Include-uninterruptible-and-IO-wait-tasks-in-LA.patch
@@ -1,0 +1,27 @@
+From 18e4b9afe10d26309427c55c07bc7342ad783a29 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Mon, 4 Apr 2016 17:56:53 +0200
+Subject: [PATCH 6/7] Include uninterruptible and IO wait tasks in LA
+
+Otherwise, the load average doesn't report tasks stuck on IO (which is
+counter-intuitive to the concept of the load average).
+---
+ manager/container.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index baae002..dffd50f 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -527,7 +527,7 @@ func (c *containerData) updateStats() error {
+ 				return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
+ 			}
+ 			stats.TaskStats = loadStats
+-			c.updateLoad(loadStats.NrRunning)
++			c.updateLoad(loadStats.NrRunning + loadStats.NrUninterruptible + loadStats.NrIoWait)
+ 			// convert to 'milliLoad' to avoid floats and preserve precision.
+ 			stats.Cpu.LoadAverage = int32(c.loadAvg * 1000)
+ 		}
+-- 
+1.9.1
+

--- a/patches/0007-Use-a-dedicated-CpuLoadReader-per-container.patch
+++ b/patches/0007-Use-a-dedicated-CpuLoadReader-per-container.patch
@@ -1,0 +1,201 @@
+From 478fe7627aecac7e51822588dd3a623e44f0d533 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Mon, 4 Apr 2016 20:57:34 +0200
+Subject: [PATCH 7/7] Use a dedicated CpuLoadReader per container
+
+This ensures each goroutine is given its own Netlink connection, and
+presumably avoids having a message destined for one goroutine read by
+another goroutine.
+---
+ manager/container.go      | 27 +++++++++++++++++++++++----
+ manager/container_test.go |  2 +-
+ manager/manager.go        | 25 +------------------------
+ manager/manager_test.go   |  2 +-
+ utils/cpuload/cpuload.go  |  2 +-
+ 5 files changed, 27 insertions(+), 31 deletions(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index dffd50f..2384a3a 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -44,6 +44,7 @@ import (
+ )
+ 
+ // Housekeeping interval.
++var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
+ var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
+ 
+ var cgroupPathRegExp = regexp.MustCompile(`devices[^:]*:(.*?)[,;$]`)
+@@ -305,7 +306,7 @@ func (c *containerData) GetProcessList(cadvisorContainer string, inHostNamespace
+ 	return processes, nil
+ }
+ 
+-func newContainerData(containerName string, memoryCache *memory.InMemoryCache, handler container.ContainerHandler, loadReader cpuload.CpuLoadReader, logUsage bool, collectorManager collector.CollectorManager, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool) (*containerData, error) {
++func newContainerData(containerName string, memoryCache *memory.InMemoryCache, handler container.ContainerHandler, logUsage bool, collectorManager collector.CollectorManager, maxHousekeepingInterval time.Duration, allowDynamicHousekeeping bool) (*containerData, error) {
+ 	if memoryCache == nil {
+ 		return nil, fmt.Errorf("nil memory storage")
+ 	}
+@@ -323,7 +324,6 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ 		housekeepingInterval:     *HousekeepingInterval,
+ 		maxHousekeepingInterval:  maxHousekeepingInterval,
+ 		allowDynamicHousekeeping: allowDynamicHousekeeping,
+-		loadReader:               loadReader,
+ 		logUsage:                 logUsage,
+ 		loadAvg:                  -1.0, // negative value indicates uninitialized.
+ 		stop:                     make(chan bool, 1),
+@@ -333,6 +333,17 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ 
+ 	cont.loadDecay = math.Exp(float64(-cont.housekeepingInterval.Seconds() / 10))
+ 
++	if *enableLoadReader {
++		// Create cpu load reader.
++		loadReader, err := cpuload.New()
++		if err != nil {
++			// TODO(rjnagal): Promote to warning once we support cpu load inside namespaces.
++			glog.Infof("Could not initialize cpu load reader for %q: %s", ref.Name, err)
++		} else {
++			cont.loadReader = loadReader
++		}
++	}
++
+ 	err = cont.updateSpec()
+ 	if err != nil {
+ 		return nil, err
+@@ -377,6 +388,16 @@ func (self *containerData) nextHousekeeping(lastHousekeeping time.Time) time.Tim
+ func (c *containerData) housekeeping() {
+ 	// Start any background goroutines - must be cleaned up in c.handler.Cleanup().
+ 	c.handler.Start()
++	defer c.handler.Cleanup()
++
++	// Initialize cpuload reader - must be cleaned up in c.loadReader.Stop()
++	if c.loadReader != nil {
++		err := c.loadReader.Start()
++		if err != nil {
++			glog.Warningf("Could not start cpu load stat collector for %q: %s", c.info.Name, err)
++		}
++		defer c.loadReader.Stop()
++	}
+ 
+ 	// Long housekeeping is either 100ms or half of the housekeeping interval.
+ 	longHousekeeping := 100 * time.Millisecond
+@@ -390,8 +411,6 @@ func (c *containerData) housekeeping() {
+ 	for {
+ 		select {
+ 		case <-c.stop:
+-			// Cleanup container resources before stopping housekeeping.
+-			c.handler.Cleanup()
+ 			// Stop housekeeping when signaled.
+ 			return
+ 		default:
+diff --git a/manager/container_test.go b/manager/container_test.go
+index 27b18d8..9bfee56 100644
+--- a/manager/container_test.go
++++ b/manager/container_test.go
+@@ -42,7 +42,7 @@ func setupContainerData(t *testing.T, spec info.ContainerSpec) (*containerData,
+ 		nil,
+ 	)
+ 	memoryCache := memory.New(60, nil)
+-	ret, err := newContainerData(containerName, memoryCache, mockHandler, nil, false, &collector.GenericCollectorManager{}, 60*time.Second, true)
++	ret, err := newContainerData(containerName, memoryCache, mockHandler, false, &collector.GenericCollectorManager{}, 60*time.Second, true)
+ 	if err != nil {
+ 		t.Fatal(err)
+ 	}
+diff --git a/manager/manager.go b/manager/manager.go
+index eb8d2cb..701b22c 100644
+--- a/manager/manager.go
++++ b/manager/manager.go
+@@ -35,7 +35,6 @@ import (
+ 	"github.com/google/cadvisor/fs"
+ 	info "github.com/google/cadvisor/info/v1"
+ 	"github.com/google/cadvisor/info/v2"
+-	"github.com/google/cadvisor/utils/cpuload"
+ 	"github.com/google/cadvisor/utils/oomparser"
+ 	"github.com/google/cadvisor/utils/sysfs"
+ 
+@@ -45,7 +44,6 @@ import (
+ 
+ var globalHousekeepingInterval = flag.Duration("global_housekeeping_interval", 1*time.Minute, "Interval between global housekeepings")
+ var logCadvisorUsage = flag.Bool("log_cadvisor_usage", false, "Whether to log the usage of the cAdvisor container")
+-var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
+ var eventStorageAgeLimit = flag.String("event_storage_age_limit", "default=24h", "Max length of time for which to store events (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or \"default\" and the value is a duration. Default is applied to all non-specified event types")
+ var eventStorageEventLimit = flag.String("event_storage_event_limit", "default=100000", "Max number of events to store (per type). Value is a comma separated list of key values, where the keys are event types (e.g.: creation, oom) or \"default\" and the value is an integer. Default is applied to all non-specified event types")
+ var applicationMetricsCountLimit = flag.Int("application_metrics_count_limit", 100, "Max number of application metrics to store (per container)")
+@@ -196,7 +194,6 @@ type manager struct {
+ 	quitChannels             []chan error
+ 	cadvisorContainer        string
+ 	inHostNamespace          bool
+-	loadReader               cpuload.CpuLoadReader
+ 	eventHandler             events.EventManager
+ 	startupTime              time.Time
+ 	maxHousekeepingInterval  time.Duration
+@@ -221,22 +218,6 @@ func (self *manager) Start() error {
+ 	self.DockerInfo()
+ 	self.DockerImages()
+ 
+-	if *enableLoadReader {
+-		// Create cpu load reader.
+-		cpuLoadReader, err := cpuload.New()
+-		if err != nil {
+-			// TODO(rjnagal): Promote to warning once we support cpu load inside namespaces.
+-			glog.Infof("Could not initialize cpu load reader: %s", err)
+-		} else {
+-			err = cpuLoadReader.Start()
+-			if err != nil {
+-				glog.Warningf("Could not start cpu load stat collector: %s", err)
+-			} else {
+-				self.loadReader = cpuLoadReader
+-			}
+-		}
+-	}
+-
+ 	// Watch for OOMs.
+ 	err = self.watchForNewOoms()
+ 	if err != nil {
+@@ -289,10 +270,6 @@ func (self *manager) Stop() error {
+ 		}
+ 	}
+ 	self.quitChannels = make([]chan error, 0, 2)
+-	if self.loadReader != nil {
+-		self.loadReader.Stop()
+-		self.loadReader = nil
+-	}
+ 	return nil
+ }
+ 
+@@ -777,7 +754,7 @@ func (m *manager) createContainer(containerName string) error {
+ 	}
+ 
+ 	logUsage := *logCadvisorUsage && containerName == m.cadvisorContainer
+-	cont, err := newContainerData(containerName, m.memoryCache, handler, m.loadReader, logUsage, collectorManager, m.maxHousekeepingInterval, m.allowDynamicHousekeeping)
++	cont, err := newContainerData(containerName, m.memoryCache, handler, logUsage, collectorManager, m.maxHousekeepingInterval, m.allowDynamicHousekeeping)
+ 	if err != nil {
+ 		return err
+ 	}
+diff --git a/manager/manager_test.go b/manager/manager_test.go
+index cc426a5..78a154e 100644
+--- a/manager/manager_test.go
++++ b/manager/manager_test.go
+@@ -53,7 +53,7 @@ func createManagerAndAddContainers(
+ 			spec,
+ 			nil,
+ 		).Once()
+-		cont, err := newContainerData(name, memoryCache, mockHandler, nil, false, &collector.GenericCollectorManager{}, 60*time.Second, true)
++		cont, err := newContainerData(name, memoryCache, mockHandler, false, &collector.GenericCollectorManager{}, 60*time.Second, true)
+ 		if err != nil {
+ 			t.Fatal(err)
+ 		}
+diff --git a/utils/cpuload/cpuload.go b/utils/cpuload/cpuload.go
+index 78b2592..e536d90 100644
+--- a/utils/cpuload/cpuload.go
++++ b/utils/cpuload/cpuload.go
+@@ -41,6 +41,6 @@ func New() (CpuLoadReader, error) {
+ 	if err != nil {
+ 		return nil, fmt.Errorf("failed to create a netlink based cpuload reader: %v", err)
+ 	}
+-	glog.Info("Using a netlink-based load reader")
++	glog.V(3).Info("Using a netlink-based load reader")
+ 	return reader, nil
+ }
+-- 
+1.9.1
+


### PR DESCRIPTION
- Add uninterruptible and IO wait tasks in LA
- Use a dedicated CpuLoadReader per container

@fancyremarker : if you don't mind, I'll roll this out to shared stacks and then production shortly (probably tomorrow) in order to get some mileage out of https://github.com/google/cadvisor/pull/1188