### PR TITLE
Probe LA on independent interval

### DIFF
--- a/patches/0001-Add-container_id-as-tag.patch
+++ b/patches/0001-Add-container_id-as-tag.patch
@@ -1,7 +1,7 @@
 From 7a55128955105f3a8755a9abf1c384e7be9fc925 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Mon, 4 Apr 2016 21:31:01 +0200
-Subject: [PATCH 1/7] Add container_id as tag
+Subject: [PATCH] Add container_id as tag
 
 Dereferenced aliases can be nice, but a predictable container ID is nice
 too.

--- a/patches/0002-Panic-and-dump-stacks-on-housekeeping-time-out.patch
+++ b/patches/0002-Panic-and-dump-stacks-on-housekeeping-time-out.patch
@@ -1,7 +1,7 @@
 From 18d4b36a15c9dd3137e71b7eb3e31f80f6797b25 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Fri, 1 Apr 2016 11:23:38 +0200
-Subject: [PATCH 2/7] Panic and dump stacks on housekeeping time out
+Subject: [PATCH] Panic and dump stacks on housekeeping time out
 
 We'd rather have a process manager restart the entire cAdvisor process
 rather than stop reporting altogether for a given container (which is

--- a/patches/0003-Add-support-for-UNIX-sockets.patch
+++ b/patches/0003-Add-support-for-UNIX-sockets.patch
@@ -1,7 +1,7 @@
 From b0b131b72ee9f5489a187714e464856dfa927beb Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Wed, 30 Mar 2016 10:17:58 +0200
-Subject: [PATCH 3/7] Add support for UNIX sockets
+Subject: [PATCH] Add support for UNIX sockets
 
 ---
  cadvisor.go | 41 +++++++++++++++++++++++++++++++++++------

--- a/patches/0004-Don-t-allocate-4GB-of-memory-on-netlink-conn.patch
+++ b/patches/0004-Don-t-allocate-4GB-of-memory-on-netlink-conn.patch
@@ -1,7 +1,7 @@
 From 3d064720a27e6ec14f5b282eacfd3a62867e02c8 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Thu, 31 Mar 2016 23:36:08 +0200
-Subject: [PATCH 4/7] Don't allocate 4GB of memory on netlink conn
+Subject: [PATCH] Don't allocate 4GB of memory on netlink conn
 
 ---
  utils/cpuload/netlink/conn.go    |  8 ++++++++

--- a/patches/0005-Account-for-Memory-RSS.patch
+++ b/patches/0005-Account-for-Memory-RSS.patch
@@ -1,7 +1,7 @@
 From 470af9c7088587eee26272c0117169a073c12e98 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Fri, 1 Apr 2016 10:38:12 +0200
-Subject: [PATCH 5/7] Account for Memory RSS
+Subject: [PATCH] Account for Memory RSS
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/patches/0006-Include-uninterruptible-and-IO-wait-tasks-in-LA.patch
+++ b/patches/0006-Include-uninterruptible-and-IO-wait-tasks-in-LA.patch
@@ -1,7 +1,7 @@
 From 18e4b9afe10d26309427c55c07bc7342ad783a29 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Mon, 4 Apr 2016 17:56:53 +0200
-Subject: [PATCH 6/7] Include uninterruptible and IO wait tasks in LA
+Subject: [PATCH] Include uninterruptible and IO wait tasks in LA
 
 Otherwise, the load average doesn't report tasks stuck on IO (which is
 counter-intuitive to the concept of the load average).

--- a/patches/0007-Use-a-dedicated-CpuLoadReader-per-container.patch
+++ b/patches/0007-Use-a-dedicated-CpuLoadReader-per-container.patch
@@ -1,7 +1,7 @@
 From 478fe7627aecac7e51822588dd3a623e44f0d533 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Mon, 4 Apr 2016 20:57:34 +0200
-Subject: [PATCH 7/7] Use a dedicated CpuLoadReader per container
+Subject: [PATCH] Use a dedicated CpuLoadReader per container
 
 This ensures each goroutine is given its own Netlink connection, and
 presumably avoids having a message destined for one goroutine read by

--- a/patches/0008-Probe-LA-independent-of-housekeeping-interval.patch
+++ b/patches/0008-Probe-LA-independent-of-housekeeping-interval.patch
@@ -1,0 +1,272 @@
+From b71242f12184bf59ea2326833939d8d37fcc6f59 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Mon, 4 Apr 2016 17:59:38 +0200
+Subject: [PATCH] Probe LA independent of housekeeping interval
+
+Load Average is a metric that inherently relies on being probed for
+frequently (otherwise, it ends up being dependent on the luck of the
+draw more so than on the actual value). This updates the container
+manager to run the LA probe on a different schedule from the regular
+housekeeping, and uses the last observed value when reporting.
+---
+ manager/container.go | 128 ++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 101 insertions(+), 27 deletions(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index 2384a3a..2f1e5fb 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -20,16 +20,16 @@ import (
+ 	"io/ioutil"
+ 	"math"
+ 	"math/rand"
++	"os"
+ 	"os/exec"
+ 	"path"
+ 	"regexp"
++	"runtime/pprof"
+ 	"sort"
+ 	"strconv"
+ 	"strings"
+ 	"sync"
+ 	"time"
+-	"runtime/pprof"
+-	"os"
+ 
+ 	"github.com/google/cadvisor/cache/memory"
+ 	"github.com/google/cadvisor/collector"
+@@ -46,6 +46,7 @@ import (
+ // Housekeeping interval.
+ var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
+ var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
++var LoadreaderInterval = flag.Duration("load_reader_interval", 1*time.Second, "Interval between load reader probes")
+ 
+ var cgroupPathRegExp = regexp.MustCompile(`devices[^:]*:(.*?)[,;$]`)
+ 
+@@ -62,15 +63,23 @@ type containerData struct {
+ 	lock                     sync.Mutex
+ 	loadReader               cpuload.CpuLoadReader
+ 	summaryReader            *summary.StatsSummary
+-	loadAvg                  float64 // smoothed load average seen so far.
+ 	housekeepingInterval     time.Duration
+ 	maxHousekeepingInterval  time.Duration
+ 	allowDynamicHousekeeping bool
+ 	lastUpdatedTime          time.Time
+ 	lastErrorTime            time.Time
+ 
++	// smoothed load average seen so far.
++	loadAvg float64
++	// How often load average should be checked (samples are unreliable by nature)
++	loadreaderInterval time.Duration
+ 	// Decay value used for load average smoothing. Interval length of 10 seconds is used.
+ 	loadDecay float64
++	loadStop  chan bool
++	loadLock  sync.Mutex
++
++	// last taskstats
++	taskStats info.LoadStats
+ 
+ 	// Whether to log the usage of this container when it is updated.
+ 	logUsage bool
+@@ -94,7 +103,8 @@ func jitter(duration time.Duration, maxFactor float64) time.Duration {
+ }
+ 
+ func (c *containerData) Start() error {
+-	go c.housekeeping()
++	go c.doHousekeepingLoop()
++	go c.doLoadReaderLoop()
+ 	return nil
+ }
+ 
+@@ -104,6 +114,7 @@ func (c *containerData) Stop() error {
+ 		return err
+ 	}
+ 	c.stop <- true
++	c.loadStop <- true
+ 	return nil
+ }
+ 
+@@ -326,13 +337,14 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ 		allowDynamicHousekeeping: allowDynamicHousekeeping,
+ 		logUsage:                 logUsage,
+ 		loadAvg:                  -1.0, // negative value indicates uninitialized.
++		loadreaderInterval:       *LoadreaderInterval,
++		loadDecay:                math.Exp(float64(-(*LoadreaderInterval).Seconds() / 10)),
++		loadStop:                 make(chan bool, 1),
+ 		stop:                     make(chan bool, 1),
+ 		collectorManager:         collectorManager,
+ 	}
+ 	cont.info.ContainerReference = ref
+ 
+-	cont.loadDecay = math.Exp(float64(-cont.housekeepingInterval.Seconds() / 10))
+-
+ 	if *enableLoadReader {
+ 		// Create cpu load reader.
+ 		loadReader, err := cpuload.New()
+@@ -385,7 +397,7 @@ func (self *containerData) nextHousekeeping(lastHousekeeping time.Time) time.Tim
+ }
+ 
+ // TODO(vmarmol): Implement stats collecting as a custom collector.
+-func (c *containerData) housekeeping() {
++func (c *containerData) doHousekeepingLoop() {
+ 	// Start any background goroutines - must be cleaned up in c.handler.Cleanup().
+ 	c.handler.Start()
+ 	defer c.handler.Cleanup()
+@@ -405,7 +417,6 @@ func (c *containerData) housekeeping() {
+ 		longHousekeeping = *HousekeepingInterval / 2
+ 	}
+ 
+-	// Housekeep every second.
+ 	glog.V(3).Infof("Start housekeeping for container %q\n", c.info.Name)
+ 	lastHousekeeping := time.Now()
+ 	for {
+@@ -416,7 +427,7 @@ func (c *containerData) housekeeping() {
+ 		default:
+ 			// Perform housekeeping.
+ 			start := time.Now()
+-			c.housekeepingTick()
++			c.doWithTimeout((*containerData).updateStats, (*HousekeepingInterval)*2)
+ 
+ 			// Log if housekeeping took too long.
+ 			duration := time.Since(start)
+@@ -464,11 +475,13 @@ func (c *containerData) housekeeping() {
+ 	}
+ }
+ 
+-func (c *containerData) housekeepingTick() {
++type ContainerDataMethod func(c *containerData) error
++
++func (c *containerData) doWithTimeout(meth ContainerDataMethod, timeout time.Duration) {
+ 	done := make(chan bool, 1)
+ 
+ 	go func() {
+-		err := c.updateStats()
++		err := meth(c)
+ 		if err != nil {
+ 			if c.allowErrorLogging() {
+ 				glog.Infof("Failed to update stats for container \"%s\": %s", c.info.Name, err)
+@@ -480,9 +493,9 @@ func (c *containerData) housekeepingTick() {
+ 	select {
+ 	case <-done:
+ 		// Nothing to do
+-	case <-time.After(*HousekeepingInterval * 2):
++	case <-time.After(timeout):
+ 		// We timed out. Dump all goroutine stacks to facilitate troubleshooting, and panic.
+-		glog.Errorf("Housekeeping timed out for container %s", c.info.Name)
++		glog.Errorf("Timed out for: %s", c.info.Name)
+ 		pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+ 		panic("Aborting!")
+ 	}
+@@ -515,7 +528,10 @@ func (c *containerData) updateSpec() error {
+ // Calculate new smoothed load average using the new sample of runnable threads.
+ // The decay used ensures that the load will stabilize on a new constant value within
+ // 10 seconds.
+-func (c *containerData) updateLoad(newLoad uint64) {
++func (c *containerData) updateLoadAvg(newLoad uint64) {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
+ 	if c.loadAvg < 0 {
+ 		c.loadAvg = float64(newLoad) // initialize to the first seen sample for faster stabilization.
+ 	} else {
+@@ -523,6 +539,69 @@ func (c *containerData) updateLoad(newLoad uint64) {
+ 	}
+ }
+ 
++func (c *containerData) LoadAvg() float64 {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	return c.loadAvg
++}
++
++func (c *containerData) updateTaskStats(taskStats info.LoadStats) {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	c.taskStats = taskStats
++}
++
++func (c *containerData) TaskStats() info.LoadStats {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	return c.taskStats
++}
++
++func (c *containerData) doLoadReaderIteration() error {
++	path, err := c.handler.GetCgroupPath("cpu")
++	if err == nil {
++		taskStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
++		if err != nil {
++			return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
++		}
++		c.updateLoadAvg(taskStats.NrRunning + taskStats.NrUninterruptible + taskStats.NrIoWait)
++		c.updateTaskStats(taskStats)
++	}
++
++	return nil
++}
++
++func (c *containerData) doLoadReaderLoop() {
++	if c.loadReader == nil {
++		// Load reader is disabled. Don't even start the loop.
++		return
++	}
++
++	lastIteration := time.Now()
++	for {
++		select {
++		case <-c.loadStop:
++			return
++		default:
++			c.doWithTimeout((*containerData).doLoadReaderIteration, (c.loadreaderInterval)*2)
++		}
++
++		// Schedule the next housekeeping. Sleep until that time.
++		next := lastIteration.Add(jitter(c.loadreaderInterval, 1.0))
++
++		if time.Now().Before(next) {
++			time.Sleep(next.Sub(time.Now()))
++		} else {
++			next = time.Now()
++		}
++
++		lastIteration = next
++	}
++}
++
+ func (c *containerData) updateStats() error {
+ 	stats, statsErr := c.handler.GetStats()
+ 	if statsErr != nil {
+@@ -537,19 +616,14 @@ func (c *containerData) updateStats() error {
+ 	if stats == nil {
+ 		return statsErr
+ 	}
+-	if c.loadReader != nil {
+-		// TODO(vmarmol): Cache this path.
+-		path, err := c.handler.GetCgroupPath("cpu")
+-		if err == nil {
+-			loadStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
+-			if err != nil {
+-				return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
+-			}
+-			stats.TaskStats = loadStats
+-			c.updateLoad(loadStats.NrRunning + loadStats.NrUninterruptible + loadStats.NrIoWait)
+-			// convert to 'milliLoad' to avoid floats and preserve precision.
+-			stats.Cpu.LoadAverage = int32(c.loadAvg * 1000)
+-		}
++	load := c.LoadAvg()
++	if load >= 0 {
++		// convert to 'milliLoad' to avoid floats and preserve precision.
++		stats.Cpu.LoadAverage = int32(load * 1000)
++	}
++	taskStats := c.TaskStats()
++	if &taskStats != nil {
++		stats.TaskStats = taskStats
+ 	}
+ 	if c.summaryReader != nil {
+ 		err := c.summaryReader.AddSample(*stats)
+-- 
+1.9.1
+

--- a/patches/0009-Netlink-aggressively-close-cgroup-fds.patch
+++ b/patches/0009-Netlink-aggressively-close-cgroup-fds.patch
@@ -1,0 +1,27 @@
+From 6f1b4bb4dfedebbe10b1b59bc63b311790bd7149 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 5 Apr 2016 14:23:57 +0200
+Subject: [PATCH] Netlink: aggressively close cgroup fds
+
+Since we're using a shorter, fixed housekeeping interval for the CPU
+load reader, we might end up accumulating a lot of open FDs and we can't
+simply rely on the GC to garbage collect them.
+---
+ utils/cpuload/netlink/reader.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/utils/cpuload/netlink/reader.go b/utils/cpuload/netlink/reader.go
+index 4e3aa68..d38543b 100644
+--- a/utils/cpuload/netlink/reader.go
++++ b/utils/cpuload/netlink/reader.go
+@@ -66,6 +66,7 @@ func (self *NetlinkReader) GetCpuLoad(name string, path string) (info.LoadStats,
+ 	}
+ 
+ 	cfd, err := os.Open(path)
++	defer cfd.Close()
+ 	if err != nil {
+ 		return info.LoadStats{}, fmt.Errorf("failed to open cgroup path %s: %q", path, err)
+ 	}
+-- 
+1.9.1
+

--- a/patches/0010-Do-not-include-Load-Average-in-backoff-calculation.patch
+++ b/patches/0010-Do-not-include-Load-Average-in-backoff-calculation.patch
@@ -1,0 +1,28 @@
+From 03a61a55a1fd5afb045aa6a82754305a13b141ed Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 5 Apr 2016 15:50:30 +0200
+Subject: [PATCH] Do not include Load Average in backoff calculation
+
+---
+ info/v1/container.go | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/info/v1/container.go b/info/v1/container.go
+index 6e7e658..74c719e 100644
+--- a/info/v1/container.go
++++ b/info/v1/container.go
+@@ -520,7 +520,10 @@ func (a *ContainerStats) Eq(b *ContainerStats) bool {
+ // Checks equality of the stats values.
+ func (a *ContainerStats) StatsEq(b *ContainerStats) bool {
+ 	// TODO(vmarmol): Consider using this through reflection.
+-	if !reflect.DeepEqual(a.Cpu, b.Cpu) {
++	// Exclude Load Average from calculation. Since the Load Average
++	// is adjusted at each run via a calculation that is bound to make
++	// it change over time.
++	if !reflect.DeepEqual(a.Cpu.Usage, b.Cpu.Usage) {
+ 		return false
+ 	}
+ 	if !reflect.DeepEqual(a.Memory, b.Memory) {
+-- 
+1.9.1
+

--- a/patches/0011-Support-dynamic-interval-for-LA-decay-accurately.patch
+++ b/patches/0011-Support-dynamic-interval-for-LA-decay-accurately.patch
@@ -1,0 +1,194 @@
+From 054749cfe542060db45c363c17a9b20fe2575fee Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 5 Apr 2016 15:54:14 +0200
+Subject: [PATCH] Support dynamic interval for LA, decay accurately
+
+With dynamic housekeeping, the load decay must be calculated based on
+the last timestamp in order to decay over the desired time duration
+(otherwise, a data point collected a minute ago would be interpreted as
+being from last second)
+---
+ manager/container.go | 96 ++++++++++++++++++++++++++++++++--------------------
+ 1 file changed, 60 insertions(+), 36 deletions(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index 2f1e5fb..9ee2b53 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -47,6 +47,7 @@ import (
+ var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
+ var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
+ var LoadreaderInterval = flag.Duration("load_reader_interval", 1*time.Second, "Interval between load reader probes")
++var MaxLoadReaderInterval = flag.Duration("max_load_reader_interval", 60*time.Second, "Interval between load reader probes")
+ 
+ var cgroupPathRegExp = regexp.MustCompile(`devices[^:]*:(.*?)[,;$]`)
+ 
+@@ -70,13 +71,13 @@ type containerData struct {
+ 	lastErrorTime            time.Time
+ 
+ 	// smoothed load average seen so far.
+-	loadAvg float64
++	loadAvg              float64
++	loadAvgLastProbeTime time.Time
+ 	// How often load average should be checked (samples are unreliable by nature)
+ 	loadreaderInterval time.Duration
+ 	// Decay value used for load average smoothing. Interval length of 10 seconds is used.
+-	loadDecay float64
+-	loadStop  chan bool
+-	loadLock  sync.Mutex
++	loadStop chan bool
++	loadLock sync.Mutex
+ 
+ 	// last taskstats
+ 	taskStats info.LoadStats
+@@ -91,6 +92,14 @@ type containerData struct {
+ 	collectorManager collector.CollectorManager
+ }
+ 
++func DurationMin(d1 time.Duration, d2 time.Duration) time.Duration {
++	if d1 < d2 {
++		return d1
++	}
++
++	return d2
++}
++
+ // jitter returns a time.Duration between duration and duration + maxFactor * duration,
+ // to allow clients to avoid converging on periodic behavior.  If maxFactor is 0.0, a
+ // suggested default value will be chosen.
+@@ -336,9 +345,8 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ 		maxHousekeepingInterval:  maxHousekeepingInterval,
+ 		allowDynamicHousekeeping: allowDynamicHousekeeping,
+ 		logUsage:                 logUsage,
+-		loadAvg:                  -1.0, // negative value indicates uninitialized.
++		loadAvg:                  -1.0, // negative value indicates uninitialized
+ 		loadreaderInterval:       *LoadreaderInterval,
+-		loadDecay:                math.Exp(float64(-(*LoadreaderInterval).Seconds() / 10)),
+ 		loadStop:                 make(chan bool, 1),
+ 		stop:                     make(chan bool, 1),
+ 		collectorManager:         collectorManager,
+@@ -370,30 +378,30 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ }
+ 
+ // Determine when the next housekeeping should occur.
+-func (self *containerData) nextHousekeeping(lastHousekeeping time.Time) time.Time {
+-	if self.allowDynamicHousekeeping {
+-		var empty time.Time
+-		stats, err := self.memoryCache.RecentStats(self.info.Name, empty, empty, 2)
+-		if err != nil {
+-			if self.allowErrorLogging() {
+-				glog.Warningf("Failed to get RecentStats(%q) while determining the next housekeeping: %v", self.info.Name, err)
+-			}
+-		} else if len(stats) == 2 {
+-			// TODO(vishnuk): Use no processes as a signal.
+-			// Raise the interval if usage hasn't changed in the last housekeeping.
+-			if stats[0].StatsEq(stats[1]) && (self.housekeepingInterval < self.maxHousekeepingInterval) {
+-				self.housekeepingInterval *= 2
+-				if self.housekeepingInterval > self.maxHousekeepingInterval {
+-					self.housekeepingInterval = self.maxHousekeepingInterval
+-				}
+-			} else if self.housekeepingInterval != *HousekeepingInterval {
+-				// Lower interval back to the baseline.
+-				self.housekeepingInterval = *HousekeepingInterval
+-			}
+-		}
++func (c *containerData) adjustHousekeepingInterval() error {
++	if !c.allowDynamicHousekeeping {
++		return nil
+ 	}
+ 
+-	return lastHousekeeping.Add(jitter(self.housekeepingInterval, 1.0))
++	var empty time.Time
++	stats, err := c.memoryCache.RecentStats(c.info.Name, empty, empty, 2)
++	if err != nil {
++		return err
++	}
++
++	if len(stats) < 2 {
++		// Not enough stats yet to adjust housekeeping interval
++		return nil
++	}
++
++	if stats[0].StatsEq(stats[1]) {
++		c.housekeepingInterval = DurationMin(c.housekeepingInterval*2, c.maxHousekeepingInterval)
++	} else {
++		// Lower interval back to the baseline.
++		c.housekeepingInterval = *HousekeepingInterval
++	}
++
++	return nil
+ }
+ 
+ // TODO(vmarmol): Implement stats collecting as a custom collector.
+@@ -463,7 +471,11 @@ func (c *containerData) doHousekeepingLoop() {
+ 			}
+ 		}
+ 
+-		next := c.nextHousekeeping(lastHousekeeping)
++		err := c.adjustHousekeepingInterval()
++		if err != nil && c.allowErrorLogging() {
++			glog.Warningf("Failed to get RecentStats(%q) while determining the next housekeeping: %v", c.info.Name, err)
++		}
++		next := lastHousekeeping.Add(jitter(c.housekeepingInterval, 1.0))
+ 
+ 		// Schedule the next housekeeping. Sleep until that time.
+ 		if time.Now().Before(next) {
+@@ -528,15 +540,19 @@ func (c *containerData) updateSpec() error {
+ // Calculate new smoothed load average using the new sample of runnable threads.
+ // The decay used ensures that the load will stabilize on a new constant value within
+ // 10 seconds.
+-func (c *containerData) updateLoadAvg(newLoad uint64) {
++func (c *containerData) updateLoadAvg(probeTime time.Time, newTaskStats info.LoadStats) {
+ 	c.loadLock.Lock()
+ 	defer c.loadLock.Unlock()
+ 
++	newLoad := newTaskStats.NrRunning + newTaskStats.NrUninterruptible + newTaskStats.NrIoWait
+ 	if c.loadAvg < 0 {
+-		c.loadAvg = float64(newLoad) // initialize to the first seen sample for faster stabilization.
++		// We never saw a load average, just record this as the new authoritative value
++		c.loadAvg = float64(newLoad)
+ 	} else {
+-		c.loadAvg = c.loadAvg*c.loadDecay + float64(newLoad)*(1.0-c.loadDecay)
++		loadDecay := math.Exp(float64(-(probeTime.Sub(c.loadAvgLastProbeTime).Seconds() / 10)))
++		c.loadAvg = float64(newLoad)*(1.0-loadDecay) + c.loadAvg*loadDecay
+ 	}
++	c.loadAvgLastProbeTime = probeTime
+ }
+ 
+ func (c *containerData) LoadAvg() float64 {
+@@ -563,12 +579,20 @@ func (c *containerData) TaskStats() info.LoadStats {
+ func (c *containerData) doLoadReaderIteration() error {
+ 	path, err := c.handler.GetCgroupPath("cpu")
+ 	if err == nil {
+-		taskStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
++		newTaskStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
++		probeTime := time.Now()
+ 		if err != nil {
+ 			return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
+ 		}
+-		c.updateLoadAvg(taskStats.NrRunning + taskStats.NrUninterruptible + taskStats.NrIoWait)
+-		c.updateTaskStats(taskStats)
++		// Check whether we should backoff before updating task stats
++		if c.allowDynamicHousekeeping && c.TaskStats() == newTaskStats {
++			c.loadreaderInterval = DurationMin(c.loadreaderInterval*2, *MaxLoadReaderInterval)
++		} else {
++			c.loadreaderInterval = *LoadreaderInterval
++		}
++
++		c.updateTaskStats(newTaskStats)
++		c.updateLoadAvg(probeTime, newTaskStats)
+ 	}
+ 
+ 	return nil
+@@ -586,7 +610,7 @@ func (c *containerData) doLoadReaderLoop() {
+ 		case <-c.loadStop:
+ 			return
+ 		default:
+-			c.doWithTimeout((*containerData).doLoadReaderIteration, (c.loadreaderInterval)*2)
++			c.doWithTimeout((*containerData).doLoadReaderIteration, (*LoadreaderInterval)*2)
+ 		}
+ 
+ 		// Schedule the next housekeeping. Sleep until that time.
+-- 
+1.9.1
+


### PR DESCRIPTION
We can't compute a decent load average by probing netlink once every 30
seconds (and, the load decay calculation is wrong in this case).

This updates cAdvisor to use a different schedule to probe netlink and
get a container's running tasks, and gives us a *much* better
approximation of the real load average.

--

The upshot of this change should be substantially smoother LA curves.

cc @fancyremarker 