### PR TITLE
Compute sha1sum for cadvisor after build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-cadvisor
+build
 .git

--- a/build.sh
+++ b/build.sh
@@ -21,4 +21,5 @@ done
 make
 
 mkdir -p "$DEPLOY_TO"
+sha1sum cadvisor > "${DEPLOY_TO}/cadvisor.sha1sum"
 mv cadvisor "$DEPLOY_TO"

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/local_build.sh
+++ b/local_build.sh
@@ -5,10 +5,13 @@ set -o nounset
 TAG="cadvisor-factory"
 CONTAINER="${TAG}-container"
 DEPLOY_TO="/tmp"
+COPY_TO="$(cd "$(dirname "$0")"; pwd)/build"
 
 docker build -t "$TAG" .
 
 docker rm -f "$CONTAINER" 2> /dev/null || true
 docker run -it --name "$CONTAINER"  -e "DEPLOY_TO=${DEPLOY_TO}" "$TAG"
-docker cp "${CONTAINER}:${DEPLOY_TO}/cadvisor" .
+for f in cadvisor cadvisor.sha1sum; do
+  docker cp "${CONTAINER}:${DEPLOY_TO}/${f}" "$COPY_TO"
+done
 docker rm "$CONTAINER"


### PR DESCRIPTION
This will upload a sha1sum along with the binary to S3 so we can check for integrity after downloading it on an instance.

cc @fancyremarker 