### PR TITLE
Patch set updates: LA Probe, Disk usage

### DIFF
--- a/patches/0001-Add-container_id-as-tag.patch
+++ b/patches/0001-Add-container_id-as-tag.patch
@@ -1,7 +1,7 @@
 From 7a55128955105f3a8755a9abf1c384e7be9fc925 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Mon, 4 Apr 2016 21:31:01 +0200
-Subject: [PATCH 1/7] Add container_id as tag
+Subject: [PATCH] Add container_id as tag
 
 Dereferenced aliases can be nice, but a predictable container ID is nice
 too.
@@ -30,5 +30,5 @@ index 82739b5..4aeb89d 100644
  	for i := 0; i < len(points); i++ {
  		// merge with existing tags if any
 -- 
-1.9.1
+2.7.4
 

--- a/patches/0002-Panic-and-dump-stacks-on-housekeeping-time-out.patch
+++ b/patches/0002-Panic-and-dump-stacks-on-housekeeping-time-out.patch
@@ -1,7 +1,7 @@
 From 18d4b36a15c9dd3137e71b7eb3e31f80f6797b25 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Fri, 1 Apr 2016 11:23:38 +0200
-Subject: [PATCH 2/7] Panic and dump stacks on housekeeping time out
+Subject: [PATCH] Panic and dump stacks on housekeeping time out
 
 We'd rather have a process manager restart the entire cAdvisor process
 rather than stop reporting altogether for a given container (which is
@@ -55,5 +55,5 @@ index b1d8d33..baae002 100644
  }
  
 -- 
-1.9.1
+2.7.4
 

--- a/patches/0003-Add-support-for-UNIX-sockets.patch
+++ b/patches/0003-Add-support-for-UNIX-sockets.patch
@@ -1,7 +1,7 @@
 From b0b131b72ee9f5489a187714e464856dfa927beb Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Wed, 30 Mar 2016 10:17:58 +0200
-Subject: [PATCH 3/7] Add support for UNIX sockets
+Subject: [PATCH] Add support for UNIX sockets
 
 ---
  cadvisor.go | 41 +++++++++++++++++++++++++++++++++++------
@@ -92,5 +92,5 @@ index 6f6a0ad..5cd4f89 100644
  		os.Exit(0)
  	}()
 -- 
-1.9.1
+2.7.4
 

--- a/patches/0004-Don-t-allocate-4GB-of-memory-on-netlink-conn.patch
+++ b/patches/0004-Don-t-allocate-4GB-of-memory-on-netlink-conn.patch
@@ -1,7 +1,7 @@
 From 3d064720a27e6ec14f5b282eacfd3a62867e02c8 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Thu, 31 Mar 2016 23:36:08 +0200
-Subject: [PATCH 4/7] Don't allocate 4GB of memory on netlink conn
+Subject: [PATCH] Don't allocate 4GB of memory on netlink conn
 
 ---
  utils/cpuload/netlink/conn.go    |  8 ++++++++
@@ -123,5 +123,5 @@ index 7ca05f3..accf294 100644
  			if err != nil {
  				return 0, err
 -- 
-1.9.1
+2.7.4
 

--- a/patches/0005-Account-for-Memory-RSS.patch
+++ b/patches/0005-Account-for-Memory-RSS.patch
@@ -1,7 +1,7 @@
 From 470af9c7088587eee26272c0117169a073c12e98 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Fri, 1 Apr 2016 10:38:12 +0200
-Subject: [PATCH 5/7] Account for Memory RSS
+Subject: [PATCH] Account for Memory RSS
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -102,5 +102,5 @@ index aa8aafe..6c4e8e3 100644
  	series[colMemoryWorkingSet] = stats.Memory.WorkingSet
  
 -- 
-1.9.1
+2.7.4
 

--- a/patches/0006-Include-uninterruptible-and-IO-wait-tasks-in-LA.patch
+++ b/patches/0006-Include-uninterruptible-and-IO-wait-tasks-in-LA.patch
@@ -1,7 +1,7 @@
 From 18e4b9afe10d26309427c55c07bc7342ad783a29 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Mon, 4 Apr 2016 17:56:53 +0200
-Subject: [PATCH 6/7] Include uninterruptible and IO wait tasks in LA
+Subject: [PATCH] Include uninterruptible and IO wait tasks in LA
 
 Otherwise, the load average doesn't report tasks stuck on IO (which is
 counter-intuitive to the concept of the load average).
@@ -23,5 +23,5 @@ index baae002..dffd50f 100644
  			stats.Cpu.LoadAverage = int32(c.loadAvg * 1000)
  		}
 -- 
-1.9.1
+2.7.4
 

--- a/patches/0007-Use-a-dedicated-CpuLoadReader-per-container.patch
+++ b/patches/0007-Use-a-dedicated-CpuLoadReader-per-container.patch
@@ -1,7 +1,7 @@
 From 478fe7627aecac7e51822588dd3a623e44f0d533 Mon Sep 17 00:00:00 2001
 From: Thomas Orozco <thomas@orozco.fr>
 Date: Mon, 4 Apr 2016 20:57:34 +0200
-Subject: [PATCH 7/7] Use a dedicated CpuLoadReader per container
+Subject: [PATCH] Use a dedicated CpuLoadReader per container
 
 This ensures each goroutine is given its own Netlink connection, and
 presumably avoids having a message destined for one goroutine read by
@@ -197,5 +197,5 @@ index 78b2592..e536d90 100644
  	return reader, nil
  }
 -- 
-1.9.1
+2.7.4
 

--- a/patches/0008-Probe-LA-independent-of-housekeeping-interval.patch
+++ b/patches/0008-Probe-LA-independent-of-housekeeping-interval.patch
@@ -1,0 +1,272 @@
+From b71242f12184bf59ea2326833939d8d37fcc6f59 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Mon, 4 Apr 2016 17:59:38 +0200
+Subject: [PATCH] Probe LA independent of housekeeping interval
+
+Load Average is a metric that inherently relies on being probed for
+frequently (otherwise, it ends up being dependent on the luck of the
+draw more so than on the actual value). This updates the container
+manager to run the LA probe on a different schedule from the regular
+housekeeping, and uses the last observed value when reporting.
+---
+ manager/container.go | 128 ++++++++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 101 insertions(+), 27 deletions(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index 2384a3a..2f1e5fb 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -20,16 +20,16 @@ import (
+ 	"io/ioutil"
+ 	"math"
+ 	"math/rand"
++	"os"
+ 	"os/exec"
+ 	"path"
+ 	"regexp"
++	"runtime/pprof"
+ 	"sort"
+ 	"strconv"
+ 	"strings"
+ 	"sync"
+ 	"time"
+-	"runtime/pprof"
+-	"os"
+ 
+ 	"github.com/google/cadvisor/cache/memory"
+ 	"github.com/google/cadvisor/collector"
+@@ -46,6 +46,7 @@ import (
+ // Housekeeping interval.
+ var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
+ var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
++var LoadreaderInterval = flag.Duration("load_reader_interval", 1*time.Second, "Interval between load reader probes")
+ 
+ var cgroupPathRegExp = regexp.MustCompile(`devices[^:]*:(.*?)[,;$]`)
+ 
+@@ -62,15 +63,23 @@ type containerData struct {
+ 	lock                     sync.Mutex
+ 	loadReader               cpuload.CpuLoadReader
+ 	summaryReader            *summary.StatsSummary
+-	loadAvg                  float64 // smoothed load average seen so far.
+ 	housekeepingInterval     time.Duration
+ 	maxHousekeepingInterval  time.Duration
+ 	allowDynamicHousekeeping bool
+ 	lastUpdatedTime          time.Time
+ 	lastErrorTime            time.Time
+ 
++	// smoothed load average seen so far.
++	loadAvg float64
++	// How often load average should be checked (samples are unreliable by nature)
++	loadreaderInterval time.Duration
+ 	// Decay value used for load average smoothing. Interval length of 10 seconds is used.
+ 	loadDecay float64
++	loadStop  chan bool
++	loadLock  sync.Mutex
++
++	// last taskstats
++	taskStats info.LoadStats
+ 
+ 	// Whether to log the usage of this container when it is updated.
+ 	logUsage bool
+@@ -94,7 +103,8 @@ func jitter(duration time.Duration, maxFactor float64) time.Duration {
+ }
+ 
+ func (c *containerData) Start() error {
+-	go c.housekeeping()
++	go c.doHousekeepingLoop()
++	go c.doLoadReaderLoop()
+ 	return nil
+ }
+ 
+@@ -104,6 +114,7 @@ func (c *containerData) Stop() error {
+ 		return err
+ 	}
+ 	c.stop <- true
++	c.loadStop <- true
+ 	return nil
+ }
+ 
+@@ -326,13 +337,14 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ 		allowDynamicHousekeeping: allowDynamicHousekeeping,
+ 		logUsage:                 logUsage,
+ 		loadAvg:                  -1.0, // negative value indicates uninitialized.
++		loadreaderInterval:       *LoadreaderInterval,
++		loadDecay:                math.Exp(float64(-(*LoadreaderInterval).Seconds() / 10)),
++		loadStop:                 make(chan bool, 1),
+ 		stop:                     make(chan bool, 1),
+ 		collectorManager:         collectorManager,
+ 	}
+ 	cont.info.ContainerReference = ref
+ 
+-	cont.loadDecay = math.Exp(float64(-cont.housekeepingInterval.Seconds() / 10))
+-
+ 	if *enableLoadReader {
+ 		// Create cpu load reader.
+ 		loadReader, err := cpuload.New()
+@@ -385,7 +397,7 @@ func (self *containerData) nextHousekeeping(lastHousekeeping time.Time) time.Tim
+ }
+ 
+ // TODO(vmarmol): Implement stats collecting as a custom collector.
+-func (c *containerData) housekeeping() {
++func (c *containerData) doHousekeepingLoop() {
+ 	// Start any background goroutines - must be cleaned up in c.handler.Cleanup().
+ 	c.handler.Start()
+ 	defer c.handler.Cleanup()
+@@ -405,7 +417,6 @@ func (c *containerData) housekeeping() {
+ 		longHousekeeping = *HousekeepingInterval / 2
+ 	}
+ 
+-	// Housekeep every second.
+ 	glog.V(3).Infof("Start housekeeping for container %q\n", c.info.Name)
+ 	lastHousekeeping := time.Now()
+ 	for {
+@@ -416,7 +427,7 @@ func (c *containerData) housekeeping() {
+ 		default:
+ 			// Perform housekeeping.
+ 			start := time.Now()
+-			c.housekeepingTick()
++			c.doWithTimeout((*containerData).updateStats, (*HousekeepingInterval)*2)
+ 
+ 			// Log if housekeeping took too long.
+ 			duration := time.Since(start)
+@@ -464,11 +475,13 @@ func (c *containerData) housekeeping() {
+ 	}
+ }
+ 
+-func (c *containerData) housekeepingTick() {
++type ContainerDataMethod func(c *containerData) error
++
++func (c *containerData) doWithTimeout(meth ContainerDataMethod, timeout time.Duration) {
+ 	done := make(chan bool, 1)
+ 
+ 	go func() {
+-		err := c.updateStats()
++		err := meth(c)
+ 		if err != nil {
+ 			if c.allowErrorLogging() {
+ 				glog.Infof("Failed to update stats for container \"%s\": %s", c.info.Name, err)
+@@ -480,9 +493,9 @@ func (c *containerData) housekeepingTick() {
+ 	select {
+ 	case <-done:
+ 		// Nothing to do
+-	case <-time.After(*HousekeepingInterval * 2):
++	case <-time.After(timeout):
+ 		// We timed out. Dump all goroutine stacks to facilitate troubleshooting, and panic.
+-		glog.Errorf("Housekeeping timed out for container %s", c.info.Name)
++		glog.Errorf("Timed out for: %s", c.info.Name)
+ 		pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+ 		panic("Aborting!")
+ 	}
+@@ -515,7 +528,10 @@ func (c *containerData) updateSpec() error {
+ // Calculate new smoothed load average using the new sample of runnable threads.
+ // The decay used ensures that the load will stabilize on a new constant value within
+ // 10 seconds.
+-func (c *containerData) updateLoad(newLoad uint64) {
++func (c *containerData) updateLoadAvg(newLoad uint64) {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
+ 	if c.loadAvg < 0 {
+ 		c.loadAvg = float64(newLoad) // initialize to the first seen sample for faster stabilization.
+ 	} else {
+@@ -523,6 +539,69 @@ func (c *containerData) updateLoad(newLoad uint64) {
+ 	}
+ }
+ 
++func (c *containerData) LoadAvg() float64 {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	return c.loadAvg
++}
++
++func (c *containerData) updateTaskStats(taskStats info.LoadStats) {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	c.taskStats = taskStats
++}
++
++func (c *containerData) TaskStats() info.LoadStats {
++	c.loadLock.Lock()
++	defer c.loadLock.Unlock()
++
++	return c.taskStats
++}
++
++func (c *containerData) doLoadReaderIteration() error {
++	path, err := c.handler.GetCgroupPath("cpu")
++	if err == nil {
++		taskStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
++		if err != nil {
++			return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
++		}
++		c.updateLoadAvg(taskStats.NrRunning + taskStats.NrUninterruptible + taskStats.NrIoWait)
++		c.updateTaskStats(taskStats)
++	}
++
++	return nil
++}
++
++func (c *containerData) doLoadReaderLoop() {
++	if c.loadReader == nil {
++		// Load reader is disabled. Don't even start the loop.
++		return
++	}
++
++	lastIteration := time.Now()
++	for {
++		select {
++		case <-c.loadStop:
++			return
++		default:
++			c.doWithTimeout((*containerData).doLoadReaderIteration, (c.loadreaderInterval)*2)
++		}
++
++		// Schedule the next housekeeping. Sleep until that time.
++		next := lastIteration.Add(jitter(c.loadreaderInterval, 1.0))
++
++		if time.Now().Before(next) {
++			time.Sleep(next.Sub(time.Now()))
++		} else {
++			next = time.Now()
++		}
++
++		lastIteration = next
++	}
++}
++
+ func (c *containerData) updateStats() error {
+ 	stats, statsErr := c.handler.GetStats()
+ 	if statsErr != nil {
+@@ -537,19 +616,14 @@ func (c *containerData) updateStats() error {
+ 	if stats == nil {
+ 		return statsErr
+ 	}
+-	if c.loadReader != nil {
+-		// TODO(vmarmol): Cache this path.
+-		path, err := c.handler.GetCgroupPath("cpu")
+-		if err == nil {
+-			loadStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
+-			if err != nil {
+-				return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
+-			}
+-			stats.TaskStats = loadStats
+-			c.updateLoad(loadStats.NrRunning + loadStats.NrUninterruptible + loadStats.NrIoWait)
+-			// convert to 'milliLoad' to avoid floats and preserve precision.
+-			stats.Cpu.LoadAverage = int32(c.loadAvg * 1000)
+-		}
++	load := c.LoadAvg()
++	if load >= 0 {
++		// convert to 'milliLoad' to avoid floats and preserve precision.
++		stats.Cpu.LoadAverage = int32(load * 1000)
++	}
++	taskStats := c.TaskStats()
++	if &taskStats != nil {
++		stats.TaskStats = taskStats
+ 	}
+ 	if c.summaryReader != nil {
+ 		err := c.summaryReader.AddSample(*stats)
+-- 
+2.7.4
+

--- a/patches/0009-Netlink-aggressively-close-cgroup-fds.patch
+++ b/patches/0009-Netlink-aggressively-close-cgroup-fds.patch
@@ -1,0 +1,27 @@
+From 6f1b4bb4dfedebbe10b1b59bc63b311790bd7149 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 5 Apr 2016 14:23:57 +0200
+Subject: [PATCH] Netlink: aggressively close cgroup fds
+
+Since we're using a shorter, fixed housekeeping interval for the CPU
+load reader, we might end up accumulating a lot of open FDs and we can't
+simply rely on the GC to garbage collect them.
+---
+ utils/cpuload/netlink/reader.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/utils/cpuload/netlink/reader.go b/utils/cpuload/netlink/reader.go
+index 4e3aa68..d38543b 100644
+--- a/utils/cpuload/netlink/reader.go
++++ b/utils/cpuload/netlink/reader.go
+@@ -66,6 +66,7 @@ func (self *NetlinkReader) GetCpuLoad(name string, path string) (info.LoadStats,
+ 	}
+ 
+ 	cfd, err := os.Open(path)
++	defer cfd.Close()
+ 	if err != nil {
+ 		return info.LoadStats{}, fmt.Errorf("failed to open cgroup path %s: %q", path, err)
+ 	}
+-- 
+2.7.4
+

--- a/patches/0010-Do-not-include-Load-Average-in-backoff-calculation.patch
+++ b/patches/0010-Do-not-include-Load-Average-in-backoff-calculation.patch
@@ -1,0 +1,28 @@
+From 03a61a55a1fd5afb045aa6a82754305a13b141ed Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 5 Apr 2016 15:50:30 +0200
+Subject: [PATCH] Do not include Load Average in backoff calculation
+
+---
+ info/v1/container.go | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/info/v1/container.go b/info/v1/container.go
+index 6e7e658..74c719e 100644
+--- a/info/v1/container.go
++++ b/info/v1/container.go
+@@ -520,7 +520,10 @@ func (a *ContainerStats) Eq(b *ContainerStats) bool {
+ // Checks equality of the stats values.
+ func (a *ContainerStats) StatsEq(b *ContainerStats) bool {
+ 	// TODO(vmarmol): Consider using this through reflection.
+-	if !reflect.DeepEqual(a.Cpu, b.Cpu) {
++	// Exclude Load Average from calculation. Since the Load Average
++	// is adjusted at each run via a calculation that is bound to make
++	// it change over time.
++	if !reflect.DeepEqual(a.Cpu.Usage, b.Cpu.Usage) {
+ 		return false
+ 	}
+ 	if !reflect.DeepEqual(a.Memory, b.Memory) {
+-- 
+2.7.4
+

--- a/patches/0011-Support-dynamic-interval-for-LA-decay-accurately.patch
+++ b/patches/0011-Support-dynamic-interval-for-LA-decay-accurately.patch
@@ -1,0 +1,194 @@
+From 054749cfe542060db45c363c17a9b20fe2575fee Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 5 Apr 2016 15:54:14 +0200
+Subject: [PATCH] Support dynamic interval for LA, decay accurately
+
+With dynamic housekeeping, the load decay must be calculated based on
+the last timestamp in order to decay over the desired time duration
+(otherwise, a data point collected a minute ago would be interpreted as
+being from last second)
+---
+ manager/container.go | 96 ++++++++++++++++++++++++++++++++--------------------
+ 1 file changed, 60 insertions(+), 36 deletions(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index 2f1e5fb..9ee2b53 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -47,6 +47,7 @@ import (
+ var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
+ var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
+ var LoadreaderInterval = flag.Duration("load_reader_interval", 1*time.Second, "Interval between load reader probes")
++var MaxLoadReaderInterval = flag.Duration("max_load_reader_interval", 60*time.Second, "Interval between load reader probes")
+ 
+ var cgroupPathRegExp = regexp.MustCompile(`devices[^:]*:(.*?)[,;$]`)
+ 
+@@ -70,13 +71,13 @@ type containerData struct {
+ 	lastErrorTime            time.Time
+ 
+ 	// smoothed load average seen so far.
+-	loadAvg float64
++	loadAvg              float64
++	loadAvgLastProbeTime time.Time
+ 	// How often load average should be checked (samples are unreliable by nature)
+ 	loadreaderInterval time.Duration
+ 	// Decay value used for load average smoothing. Interval length of 10 seconds is used.
+-	loadDecay float64
+-	loadStop  chan bool
+-	loadLock  sync.Mutex
++	loadStop chan bool
++	loadLock sync.Mutex
+ 
+ 	// last taskstats
+ 	taskStats info.LoadStats
+@@ -91,6 +92,14 @@ type containerData struct {
+ 	collectorManager collector.CollectorManager
+ }
+ 
++func DurationMin(d1 time.Duration, d2 time.Duration) time.Duration {
++	if d1 < d2 {
++		return d1
++	}
++
++	return d2
++}
++
+ // jitter returns a time.Duration between duration and duration + maxFactor * duration,
+ // to allow clients to avoid converging on periodic behavior.  If maxFactor is 0.0, a
+ // suggested default value will be chosen.
+@@ -336,9 +345,8 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ 		maxHousekeepingInterval:  maxHousekeepingInterval,
+ 		allowDynamicHousekeeping: allowDynamicHousekeeping,
+ 		logUsage:                 logUsage,
+-		loadAvg:                  -1.0, // negative value indicates uninitialized.
++		loadAvg:                  -1.0, // negative value indicates uninitialized
+ 		loadreaderInterval:       *LoadreaderInterval,
+-		loadDecay:                math.Exp(float64(-(*LoadreaderInterval).Seconds() / 10)),
+ 		loadStop:                 make(chan bool, 1),
+ 		stop:                     make(chan bool, 1),
+ 		collectorManager:         collectorManager,
+@@ -370,30 +378,30 @@ func newContainerData(containerName string, memoryCache *memory.InMemoryCache, h
+ }
+ 
+ // Determine when the next housekeeping should occur.
+-func (self *containerData) nextHousekeeping(lastHousekeeping time.Time) time.Time {
+-	if self.allowDynamicHousekeeping {
+-		var empty time.Time
+-		stats, err := self.memoryCache.RecentStats(self.info.Name, empty, empty, 2)
+-		if err != nil {
+-			if self.allowErrorLogging() {
+-				glog.Warningf("Failed to get RecentStats(%q) while determining the next housekeeping: %v", self.info.Name, err)
+-			}
+-		} else if len(stats) == 2 {
+-			// TODO(vishnuk): Use no processes as a signal.
+-			// Raise the interval if usage hasn't changed in the last housekeeping.
+-			if stats[0].StatsEq(stats[1]) && (self.housekeepingInterval < self.maxHousekeepingInterval) {
+-				self.housekeepingInterval *= 2
+-				if self.housekeepingInterval > self.maxHousekeepingInterval {
+-					self.housekeepingInterval = self.maxHousekeepingInterval
+-				}
+-			} else if self.housekeepingInterval != *HousekeepingInterval {
+-				// Lower interval back to the baseline.
+-				self.housekeepingInterval = *HousekeepingInterval
+-			}
+-		}
++func (c *containerData) adjustHousekeepingInterval() error {
++	if !c.allowDynamicHousekeeping {
++		return nil
+ 	}
+ 
+-	return lastHousekeeping.Add(jitter(self.housekeepingInterval, 1.0))
++	var empty time.Time
++	stats, err := c.memoryCache.RecentStats(c.info.Name, empty, empty, 2)
++	if err != nil {
++		return err
++	}
++
++	if len(stats) < 2 {
++		// Not enough stats yet to adjust housekeeping interval
++		return nil
++	}
++
++	if stats[0].StatsEq(stats[1]) {
++		c.housekeepingInterval = DurationMin(c.housekeepingInterval*2, c.maxHousekeepingInterval)
++	} else {
++		// Lower interval back to the baseline.
++		c.housekeepingInterval = *HousekeepingInterval
++	}
++
++	return nil
+ }
+ 
+ // TODO(vmarmol): Implement stats collecting as a custom collector.
+@@ -463,7 +471,11 @@ func (c *containerData) doHousekeepingLoop() {
+ 			}
+ 		}
+ 
+-		next := c.nextHousekeeping(lastHousekeeping)
++		err := c.adjustHousekeepingInterval()
++		if err != nil && c.allowErrorLogging() {
++			glog.Warningf("Failed to get RecentStats(%q) while determining the next housekeeping: %v", c.info.Name, err)
++		}
++		next := lastHousekeeping.Add(jitter(c.housekeepingInterval, 1.0))
+ 
+ 		// Schedule the next housekeeping. Sleep until that time.
+ 		if time.Now().Before(next) {
+@@ -528,15 +540,19 @@ func (c *containerData) updateSpec() error {
+ // Calculate new smoothed load average using the new sample of runnable threads.
+ // The decay used ensures that the load will stabilize on a new constant value within
+ // 10 seconds.
+-func (c *containerData) updateLoadAvg(newLoad uint64) {
++func (c *containerData) updateLoadAvg(probeTime time.Time, newTaskStats info.LoadStats) {
+ 	c.loadLock.Lock()
+ 	defer c.loadLock.Unlock()
+ 
++	newLoad := newTaskStats.NrRunning + newTaskStats.NrUninterruptible + newTaskStats.NrIoWait
+ 	if c.loadAvg < 0 {
+-		c.loadAvg = float64(newLoad) // initialize to the first seen sample for faster stabilization.
++		// We never saw a load average, just record this as the new authoritative value
++		c.loadAvg = float64(newLoad)
+ 	} else {
+-		c.loadAvg = c.loadAvg*c.loadDecay + float64(newLoad)*(1.0-c.loadDecay)
++		loadDecay := math.Exp(float64(-(probeTime.Sub(c.loadAvgLastProbeTime).Seconds() / 10)))
++		c.loadAvg = float64(newLoad)*(1.0-loadDecay) + c.loadAvg*loadDecay
+ 	}
++	c.loadAvgLastProbeTime = probeTime
+ }
+ 
+ func (c *containerData) LoadAvg() float64 {
+@@ -563,12 +579,20 @@ func (c *containerData) TaskStats() info.LoadStats {
+ func (c *containerData) doLoadReaderIteration() error {
+ 	path, err := c.handler.GetCgroupPath("cpu")
+ 	if err == nil {
+-		taskStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
++		newTaskStats, err := c.loadReader.GetCpuLoad(c.info.Name, path)
++		probeTime := time.Now()
+ 		if err != nil {
+ 			return fmt.Errorf("failed to get load stat for %q - path %q, error %s", c.info.Name, path, err)
+ 		}
+-		c.updateLoadAvg(taskStats.NrRunning + taskStats.NrUninterruptible + taskStats.NrIoWait)
+-		c.updateTaskStats(taskStats)
++		// Check whether we should backoff before updating task stats
++		if c.allowDynamicHousekeeping && c.TaskStats() == newTaskStats {
++			c.loadreaderInterval = DurationMin(c.loadreaderInterval*2, *MaxLoadReaderInterval)
++		} else {
++			c.loadreaderInterval = *LoadreaderInterval
++		}
++
++		c.updateTaskStats(newTaskStats)
++		c.updateLoadAvg(probeTime, newTaskStats)
+ 	}
+ 
+ 	return nil
+@@ -586,7 +610,7 @@ func (c *containerData) doLoadReaderLoop() {
+ 		case <-c.loadStop:
+ 			return
+ 		default:
+-			c.doWithTimeout((*containerData).doLoadReaderIteration, (c.loadreaderInterval)*2)
++			c.doWithTimeout((*containerData).doLoadReaderIteration, (*LoadreaderInterval)*2)
+ 		}
+ 
+ 		// Schedule the next housekeeping. Sleep until that time.
+-- 
+2.7.4
+

--- a/patches/0012-Report-IO-metrics-to-InfluxDB.patch
+++ b/patches/0012-Report-IO-metrics-to-InfluxDB.patch
@@ -1,0 +1,50 @@
+From e0c90674b14344c08e18eeac8ed3b1d3c34e1a89 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Wed, 6 Apr 2016 19:03:34 +0200
+Subject: [PATCH] Report IO metrics to InfluxDB
+
+---
+ storage/influxdb/influxdb.go | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/storage/influxdb/influxdb.go b/storage/influxdb/influxdb.go
+index 5e80e9f..1c245ab 100644
+--- a/storage/influxdb/influxdb.go
++++ b/storage/influxdb/influxdb.go
+@@ -73,6 +73,10 @@ const (
+ 	serFsLimit string = "fs_limit"
+ 	// Filesystem usage.
+ 	serFsUsage string = "fs_usage"
++	// Serviced IO bytes
++	serIoBytes string = "io_bytes"
++	// Serviced IO operations
++	serIoOps string = "io_ops"
+ )
+ 
+ func new() (storage.StorageDriver, error) {
+@@ -201,6 +205,22 @@ func (self *influxdbStorage) containerStatsToPoints(
+ 	// RSS
+ 	points = append(points, makePoint(serMemoryRSS, stats.Memory.RSS))
+ 
++	// IO stats
++	var readBytes, writeBytes, readOps, writeOps uint64 = 0, 0, 0, 0
++
++	for _, diskStats := range stats.DiskIo.IoServiceBytes {
++		readBytes += diskStats.Stats["Read"]
++		writeBytes += diskStats.Stats["Write"]
++	}
++
++	for _, diskStats := range stats.DiskIo.IoServiced {
++		readOps += diskStats.Stats["Read"]
++		writeOps += diskStats.Stats["Write"]
++	}
++
++	points = append(points, makePoint(serIoBytes, readBytes+writeBytes))
++	points = append(points, makePoint(serIoOps, readOps+writeOps))
++
+ 	// Network Stats
+ 	points = append(points, makePoint(serRxBytes, stats.Network.RxBytes))
+ 	points = append(points, makePoint(serRxErrors, stats.Network.RxErrors))
+-- 
+2.7.4
+

--- a/patches/0013-Exit-when-unable-to-connect-to-Docker-daemon.patch
+++ b/patches/0013-Exit-when-unable-to-connect-to-Docker-daemon.patch
@@ -1,0 +1,38 @@
+From e3037c73dda77b71454637e62f5a965e755f4d86 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Thu, 7 Apr 2016 12:45:30 +0200
+Subject: [PATCH] Exit when unable to connect to Docker daemon
+
+Practically speaking, we'd rather have no cAdvisor than have a cAdvisor
+that doesn't report the metrics we care about. This change causes
+cAdvisor to exit if it can't connect to the Docker daemon (it'll then
+be restart by Upstart).
+---
+ manager/manager.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/manager/manager.go b/manager/manager.go
+index 701b22c..aa6d186 100644
+--- a/manager/manager.go
++++ b/manager/manager.go
+@@ -131,7 +131,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
+ 
+ 	dockerInfo, err := docker.DockerInfo()
+ 	if err != nil {
+-		glog.Warningf("Unable to connect to Docker: %v", err)
++		glog.Fatalf("Unable to connect to Docker: %v", err)
+ 	}
+ 	context := fs.Context{DockerRoot: docker.RootDir(), DockerInfo: dockerInfo}
+ 	fsInfo, err := fs.NewFsInfo(context)
+@@ -206,7 +206,7 @@ func (self *manager) Start() error {
+ 	// Register Docker container factory.
+ 	err := docker.Register(self, self.fsInfo, self.ignoreMetrics)
+ 	if err != nil {
+-		glog.Errorf("Docker container factory registration failed: %v.", err)
++		glog.Fatalf("Docker container factory registration failed: %v.", err)
+ 	}
+ 
+ 	// Register the raw driver.
+-- 
+2.7.4
+

--- a/patches/0014-Extract-FS-caching-into-PartitionCache.patch
+++ b/patches/0014-Extract-FS-caching-into-PartitionCache.patch
@@ -1,0 +1,1850 @@
+From 497a2db2710fe77dfe751368daea90a2ab6606c7 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Fri, 8 Apr 2016 22:18:55 +0200
+Subject: [PATCH] Extract FS caching into PartitionCache
+
+Currently, the FsInfo module caches all mounts at startup, and never
+refreshes its cache, which means volumes that are mounted later on will
+be missed.
+
+This updates FsInfo to use a separate PartitionCache that is refreshed
+when the PartitionCache is queried for information it doesn't have but
+is likely to be the result of a stale cache.
+---
+ fs/dmsetup_helper.go       |  82 ++++++++
+ fs/dmsetup_helper_test.go  |  85 ++++++++
+ fs/fs.go                   | 303 ++++------------------------
+ fs/fs_test.go              | 293 ---------------------------
+ fs/mount_helper.go         |  32 +++
+ fs/partition_cache.go      | 342 +++++++++++++++++++++++++++++++
+ fs/partition_cache_test.go | 487 +++++++++++++++++++++++++++++++++++++++++++++
+ fs/types.go                |  21 ++
+ 8 files changed, 1086 insertions(+), 559 deletions(-)
+ create mode 100644 fs/dmsetup_helper.go
+ create mode 100644 fs/dmsetup_helper_test.go
+ create mode 100644 fs/mount_helper.go
+ create mode 100644 fs/partition_cache.go
+ create mode 100644 fs/partition_cache_test.go
+
+diff --git a/fs/dmsetup_helper.go b/fs/dmsetup_helper.go
+new file mode 100644
+index 0000000..4124788
+--- /dev/null
++++ b/fs/dmsetup_helper.go
+@@ -0,0 +1,82 @@
++// Copyright 2016 Google Inc. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++// +build linux
++package fs
++
++import (
++	"fmt"
++	"os/exec"
++	"strconv"
++	"strings"
++)
++
++// dmsetupClient knows to to interact with dmsetup to retrieve information about devicemapper.
++type dmsetupClient interface {
++	table(poolName string) ([]byte, error)
++	//TODO add status(poolName string) ([]byte, error) and use it in getDMStats so we can unit test
++}
++
++// defaultDmsetupClient implements the standard behavior for interacting with dmsetup.
++type defaultDmsetupClient struct{}
++
++func (*defaultDmsetupClient) table(poolName string) ([]byte, error) {
++	return exec.Command("dmsetup", "table", poolName).Output()
++}
++
++func parseDMTable(dmTable string) (uint, uint, uint, error) {
++	dmTable = strings.Replace(dmTable, ":", " ", -1)
++	dmFields := strings.Fields(dmTable)
++
++	if len(dmFields) < 8 {
++		return 0, 0, 0, fmt.Errorf("Invalid dmsetup table output: %s", dmTable)
++	}
++
++	major, err := strconv.ParseUint(dmFields[5], 10, 32)
++	if err != nil {
++		return 0, 0, 0, err
++	}
++	minor, err := strconv.ParseUint(dmFields[6], 10, 32)
++	if err != nil {
++		return 0, 0, 0, err
++	}
++	dataBlkSize, err := strconv.ParseUint(dmFields[7], 10, 32)
++	if err != nil {
++		return 0, 0, 0, err
++	}
++
++	return uint(major), uint(minor), uint(dataBlkSize), nil
++}
++
++func parseDMStatus(dmStatus string) (uint64, uint64, error) {
++	dmStatus = strings.Replace(dmStatus, "/", " ", -1)
++	dmFields := strings.Fields(dmStatus)
++
++	if len(dmFields) < 8 {
++		return 0, 0, fmt.Errorf("Invalid dmsetup status output: %s", dmStatus)
++	}
++
++	used, err := strconv.ParseUint(dmFields[6], 10, 64)
++	if err != nil {
++		return 0, 0, err
++	}
++	total, err := strconv.ParseUint(dmFields[7], 10, 64)
++	if err != nil {
++		return 0, 0, err
++	}
++
++	return used, total, nil
++}
++
++var _ dmsetupClient = &defaultDmsetupClient{}
+diff --git a/fs/dmsetup_helper_test.go b/fs/dmsetup_helper_test.go
+new file mode 100644
+index 0000000..2b50dcc
+--- /dev/null
++++ b/fs/dmsetup_helper_test.go
+@@ -0,0 +1,85 @@
++// Copyright 2016 Google Inc. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++// +build linux
++package fs
++
++import (
++	"testing"
++)
++
++type testDmsetup struct {
++	data []byte
++	err  error
++}
++
++func (t *testDmsetup) table(poolName string) ([]byte, error) {
++	return t.data, t.err
++}
++
++var dmTableTests = []struct {
++	dmTable     string
++	major       uint
++	minor       uint
++	dataBlkSize uint
++	errExpected bool
++}{
++	{`0 409534464 thin-pool 253:6 253:7 128 32768 1 skip_block_zeroing`, 253, 7, 128, false},
++	{`0 409534464 thin-pool 253:6 258:9 512 32768 1 skip_block_zeroing otherstuff`, 258, 9, 512, false},
++	{`Invalid status line`, 0, 0, 0, false},
++}
++
++func TestParseDMTable(t *testing.T) {
++	for _, tt := range dmTableTests {
++		major, minor, dataBlkSize, err := parseDMTable(tt.dmTable)
++		if tt.errExpected && err != nil {
++			t.Errorf("parseDMTable(%q) expected error", tt.dmTable)
++		}
++		if major != tt.major {
++			t.Errorf("parseDMTable(%q) wrong major value => %q, want %q", tt.dmTable, major, tt.major)
++		}
++		if minor != tt.minor {
++			t.Errorf("parseDMTable(%q) wrong minor value => %q, want %q", tt.dmTable, minor, tt.minor)
++		}
++		if dataBlkSize != tt.dataBlkSize {
++			t.Errorf("parseDMTable(%q) wrong dataBlkSize value => %q, want %q", tt.dmTable, dataBlkSize, tt.dataBlkSize)
++		}
++	}
++}
++
++var dmStatusTests = []struct {
++	dmStatus    string
++	used        uint64
++	total       uint64
++	errExpected bool
++}{
++	{`0 409534464 thin-pool 64085 3705/4161600 88106/3199488 - rw no_discard_passdown queue_if_no_space -`, 88106, 3199488, false},
++	{`0 209715200 thin-pool 707 1215/524288 30282/1638400 - rw discard_passdown`, 30282, 1638400, false},
++	{`Invalid status line`, 0, 0, false},
++}
++
++func TestParseDMStatus(t *testing.T) {
++	for _, tt := range dmStatusTests {
++		used, total, err := parseDMStatus(tt.dmStatus)
++		if tt.errExpected && err != nil {
++			t.Errorf("parseDMStatus(%q) expected error", tt.dmStatus)
++		}
++		if used != tt.used {
++			t.Errorf("parseDMStatus(%q) wrong used value => %q, want %q", tt.dmStatus, used, tt.used)
++		}
++		if total != tt.total {
++			t.Errorf("parseDMStatus(%q) wrong total value => %q, want %q", tt.dmStatus, total, tt.total)
++		}
++	}
++}
+diff --git a/fs/fs.go b/fs/fs.go
+index d6e9e27..458d8c4 100644
+--- a/fs/fs.go
++++ b/fs/fs.go
+@@ -1,4 +1,4 @@
+-// Copyright 2014 Google Inc. All Rights Reserved.
++// Copyright 2014 Google Inc. All Rights Reserved.&
+ //
+ // Licensed under the Apache License, Version 2.0 (the "License");
+ // you may not use this file except in compliance with the License.
+@@ -19,45 +19,23 @@ package fs
+ 
+ import (
+ 	"bufio"
+-	"encoding/json"
+ 	"fmt"
+ 	"io/ioutil"
+ 	"os"
+ 	"os/exec"
+ 	"path"
+-	"path/filepath"
+ 	"regexp"
+ 	"strconv"
+ 	"strings"
+ 	"syscall"
+ 	"time"
+ 
+-	"github.com/docker/docker/pkg/mount"
+ 	"github.com/golang/glog"
+ 	zfs "github.com/mistifyio/go-zfs"
+ )
+ 
+-const (
+-	LabelSystemRoot   = "root"
+-	LabelDockerImages = "docker-images"
+-)
+-
+-type partition struct {
+-	mountpoint string
+-	major      uint
+-	minor      uint
+-	fsType     string
+-	blockSize  uint
+-}
+-
+ type RealFsInfo struct {
+-	// Map from block device path to partition information.
+-	partitions map[string]partition
+-	// Map from label to block device path.
+-	// Labels are intent-specific tags that are auto-detected.
+-	labels map[string]string
+-
+-	dmsetup dmsetupClient
++	partitionCache PartitionCache
+ }
+ 
+ type Context struct {
+@@ -67,169 +45,40 @@ type Context struct {
+ }
+ 
+ func NewFsInfo(context Context) (FsInfo, error) {
+-	mounts, err := mount.GetMounts()
+-	if err != nil {
+-		return nil, err
+-	}
+ 	fsInfo := &RealFsInfo{
+-		partitions: make(map[string]partition, 0),
+-		labels:     make(map[string]string, 0),
+-		dmsetup:    &defaultDmsetupClient{},
+-	}
+-	supportedFsType := map[string]bool{
+-		// all ext systems are checked through prefix.
+-		"btrfs": true,
+-		"xfs":   true,
+-		"zfs":   true,
+-	}
+-	for _, mount := range mounts {
+-		var Fstype string
+-		if !strings.HasPrefix(mount.Fstype, "ext") && !supportedFsType[mount.Fstype] {
+-			continue
+-		}
+-		// Avoid bind mounts.
+-		if _, ok := fsInfo.partitions[mount.Source]; ok {
+-			continue
+-		}
+-		if mount.Fstype == "zfs" {
+-			Fstype = mount.Fstype
+-		}
+-		fsInfo.partitions[mount.Source] = partition{
+-			fsType:     Fstype,
+-			mountpoint: mount.Mountpoint,
+-			major:      uint(mount.Major),
+-			minor:      uint(mount.Minor),
+-		}
+-	}
+-
+-	// need to call this before the log line below printing out the partitions, as this function may
+-	// add a "partition" for devicemapper to fsInfo.partitions
+-	fsInfo.addDockerImagesLabel(context)
+-
+-	glog.Infof("Filesystem partitions: %+v", fsInfo.partitions)
+-	fsInfo.addSystemRootLabel()
+-	return fsInfo, nil
+-}
+-
+-// getDockerDeviceMapperInfo returns information about the devicemapper device and "partition" if
+-// docker is using devicemapper for its storage driver. If a loopback device is being used, don't
+-// return any information or error, as we want to report based on the actual partition where the
+-// loopback file resides, inside of the loopback file itself.
+-func (self *RealFsInfo) getDockerDeviceMapperInfo(dockerInfo map[string]string) (string, *partition, error) {
+-	if storageDriver, ok := dockerInfo["Driver"]; ok && storageDriver != DeviceMapper.String() {
+-		return "", nil, nil
+-	}
+-
+-	var driverStatus [][]string
+-	if err := json.Unmarshal([]byte(dockerInfo["DriverStatus"]), &driverStatus); err != nil {
+-		return "", nil, err
+-	}
+-
+-	dataLoopFile := dockerStatusValue(driverStatus, "Data loop file")
+-	if len(dataLoopFile) > 0 {
+-		return "", nil, nil
+-	}
+-
+-	dev, major, minor, blockSize, err := dockerDMDevice(driverStatus, self.dmsetup)
+-	if err != nil {
+-		return "", nil, err
++		partitionCache: NewPartitionCache(context),
+ 	}
+ 
+-	return dev, &partition{
+-		fsType:    DeviceMapper.String(),
+-		major:     major,
+-		minor:     minor,
+-		blockSize: blockSize,
+-	}, nil
+-}
+-
+-// addSystemRootLabel attempts to determine which device contains the mount for /.
+-func (self *RealFsInfo) addSystemRootLabel() {
+-	for src, p := range self.partitions {
+-		if p.mountpoint == "/" {
+-			if _, ok := self.labels[LabelSystemRoot]; !ok {
+-				self.labels[LabelSystemRoot] = src
+-			}
+-		}
+-	}
+-}
+-
+-// addDockerImagesLabel attempts to determine which device contains the mount for docker images.
+-func (self *RealFsInfo) addDockerImagesLabel(context Context) {
+-	dockerDev, dockerPartition, err := self.getDockerDeviceMapperInfo(context.DockerInfo)
+-	if err != nil {
+-		glog.Warningf("Could not get Docker devicemapper device: %v", err)
+-	}
+-	if len(dockerDev) > 0 && dockerPartition != nil {
+-		self.partitions[dockerDev] = *dockerPartition
+-		self.labels[LabelDockerImages] = dockerDev
+-	} else {
+-		dockerPaths := getDockerImagePaths(context)
+-
+-		for src, p := range self.partitions {
+-			self.updateDockerImagesPath(src, p.mountpoint, dockerPaths)
+-		}
+-	}
+-}
++	partitions := make([]partition, 0)
++	fsInfo.partitionCache.ApplyOverPartitions(func(_ string, p partition) error {
++		partitions = append(partitions, p)
++		return nil
++	})
+ 
+-// Generate a list of possible mount points for docker image management from the docker root directory.
+-// Right now, we look for each type of supported graph driver directories, but we can do better by parsing
+-// some of the context from `docker info`.
+-func getDockerImagePaths(context Context) []string {
+-	// TODO(rjnagal): Detect docker root and graphdriver directories from docker info.
+-	dockerRoot := context.DockerRoot
+-	dockerImagePaths := []string{}
+-	for _, dir := range []string{"devicemapper", "btrfs", "aufs", "overlay", "zfs"} {
+-		dockerImagePaths = append(dockerImagePaths, path.Join(dockerRoot, dir))
+-	}
+-	for dockerRoot != "/" && dockerRoot != "." {
+-		dockerImagePaths = append(dockerImagePaths, dockerRoot)
+-		dockerRoot = filepath.Dir(dockerRoot)
+-	}
+-	dockerImagePaths = append(dockerImagePaths, "/")
+-	return dockerImagePaths
+-}
++	glog.Infof("Filesystem partitions: %+v", partitions)
+ 
+-// This method compares the mountpoint with possible docker image mount points. If a match is found,
+-// docker images label is added to the partition.
+-func (self *RealFsInfo) updateDockerImagesPath(source string, mountpoint string, dockerImagePaths []string) {
+-	for _, v := range dockerImagePaths {
+-		if v == mountpoint {
+-			if i, ok := self.labels[LabelDockerImages]; ok {
+-				// pick the innermost mountpoint.
+-				mnt := self.partitions[i].mountpoint
+-				if len(mnt) < len(mountpoint) {
+-					self.labels[LabelDockerImages] = source
+-				}
+-			} else {
+-				self.labels[LabelDockerImages] = source
+-			}
+-		}
+-	}
++	return fsInfo, nil
+ }
+ 
+ func (self *RealFsInfo) GetDeviceForLabel(label string) (string, error) {
+-	dev, ok := self.labels[label]
+-	if !ok {
+-		return "", fmt.Errorf("non-existent label %q", label)
+-	}
+-	return dev, nil
++	return self.partitionCache.DeviceNameForLabel(label)
+ }
+ 
+ func (self *RealFsInfo) GetLabelsForDevice(device string) ([]string, error) {
+-	labels := []string{}
+-	for label, dev := range self.labels {
+-		if dev == device {
++	labels := make([]string, 0)
++	self.partitionCache.ApplyOverLabels(func(label string, deviceForLabel string) error {
++		if device == deviceForLabel {
+ 			labels = append(labels, label)
+ 		}
+-	}
++		return nil
++	})
+ 	return labels, nil
+ }
+ 
+ func (self *RealFsInfo) GetMountpointForDevice(dev string) (string, error) {
+-	p, ok := self.partitions[dev]
+-	if !ok {
+-		return "", fmt.Errorf("no partition info for device %q", dev)
++	p, err := self.partitionCache.PartitionForDevice(dev)
++	if err != nil {
++		return "", err
+ 	}
+ 	return p.mountpoint, nil
+ }
+@@ -241,7 +90,8 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	for device, partition := range self.partitions {
++
++	self.partitionCache.ApplyOverPartitions(func(device string, partition partition) error {
+ 		_, hasMount := mountSet[partition.mountpoint]
+ 		_, hasDevice := deviceSet[device]
+ 		if mountSet == nil || (hasMount && !hasDevice) {
+@@ -260,6 +110,7 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
+ 				fs.Capacity, fs.Free, fs.Available, fs.Inodes, fs.InodesFree, err = getVfsStats(partition.mountpoint)
+ 				fs.Type = VFS
+ 			}
++
+ 			if err != nil {
+ 				glog.Errorf("Stat fs failed. Error: %v", err)
+ 			} else {
+@@ -273,7 +124,10 @@ func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, er
+ 				filesystems = append(filesystems, fs)
+ 			}
+ 		}
+-	}
++
++		return nil
++	})
++
+ 	return filesystems, nil
+ }
+ 
+@@ -352,12 +206,11 @@ func (self *RealFsInfo) GetDirFsDevice(dir string) (*DeviceInfo, error) {
+ 	}
+ 	major := major(buf.Dev)
+ 	minor := minor(buf.Dev)
+-	for device, partition := range self.partitions {
+-		if partition.major == major && partition.minor == minor {
+-			return &DeviceInfo{device, major, minor}, nil
+-		}
++	deviceInfo, err := self.partitionCache.DeviceInfoForMajorMinor(major, minor)
++	if err != nil {
++		return nil, err
+ 	}
+-	return nil, fmt.Errorf("could not find device with major: %d, minor: %d in cached partitions map", major, minor)
++	return deviceInfo, nil
+ }
+ 
+ func (self *RealFsInfo) GetDirUsage(dir string, timeout time.Duration) (uint64, error) {
+@@ -399,6 +252,13 @@ func (self *RealFsInfo) GetDirUsage(dir string, timeout time.Duration) (uint64,
+ 	return usageInKb * 1024, nil
+ }
+ 
++func (self *RealFsInfo) RefreshCache() {
++	err := self.partitionCache.Refresh()
++	if err != nil {
++		glog.Warningf("Failed to refresh partition cache: %s")
++	}
++}
++
+ func getVfsStats(path string) (total uint64, free uint64, avail uint64, inodes uint64, inodesFree uint64, err error) {
+ 	var s syscall.Statfs_t
+ 	if err = syscall.Statfs(path, &s); err != nil {
+@@ -412,75 +272,6 @@ func getVfsStats(path string) (total uint64, free uint64, avail uint64, inodes u
+ 	return total, free, avail, inodes, inodesFree, nil
+ }
+ 
+-func dockerStatusValue(status [][]string, target string) string {
+-	for _, v := range status {
+-		if len(v) == 2 && strings.ToLower(v[0]) == strings.ToLower(target) {
+-			return v[1]
+-		}
+-	}
+-	return ""
+-}
+-
+-// dmsetupClient knows to to interact with dmsetup to retrieve information about devicemapper.
+-type dmsetupClient interface {
+-	table(poolName string) ([]byte, error)
+-	//TODO add status(poolName string) ([]byte, error) and use it in getDMStats so we can unit test
+-}
+-
+-// defaultDmsetupClient implements the standard behavior for interacting with dmsetup.
+-type defaultDmsetupClient struct{}
+-
+-var _ dmsetupClient = &defaultDmsetupClient{}
+-
+-func (*defaultDmsetupClient) table(poolName string) ([]byte, error) {
+-	return exec.Command("dmsetup", "table", poolName).Output()
+-}
+-
+-// Devicemapper thin provisioning is detailed at
+-// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
+-func dockerDMDevice(driverStatus [][]string, dmsetup dmsetupClient) (string, uint, uint, uint, error) {
+-	poolName := dockerStatusValue(driverStatus, "Pool Name")
+-	if len(poolName) == 0 {
+-		return "", 0, 0, 0, fmt.Errorf("Could not get dm pool name")
+-	}
+-
+-	out, err := dmsetup.table(poolName)
+-	if err != nil {
+-		return "", 0, 0, 0, err
+-	}
+-
+-	major, minor, dataBlkSize, err := parseDMTable(string(out))
+-	if err != nil {
+-		return "", 0, 0, 0, err
+-	}
+-
+-	return poolName, major, minor, dataBlkSize, nil
+-}
+-
+-func parseDMTable(dmTable string) (uint, uint, uint, error) {
+-	dmTable = strings.Replace(dmTable, ":", " ", -1)
+-	dmFields := strings.Fields(dmTable)
+-
+-	if len(dmFields) < 8 {
+-		return 0, 0, 0, fmt.Errorf("Invalid dmsetup status output: %s", dmTable)
+-	}
+-
+-	major, err := strconv.ParseUint(dmFields[5], 10, 32)
+-	if err != nil {
+-		return 0, 0, 0, err
+-	}
+-	minor, err := strconv.ParseUint(dmFields[6], 10, 32)
+-	if err != nil {
+-		return 0, 0, 0, err
+-	}
+-	dataBlkSize, err := strconv.ParseUint(dmFields[7], 10, 32)
+-	if err != nil {
+-		return 0, 0, 0, err
+-	}
+-
+-	return uint(major), uint(minor), uint(dataBlkSize), nil
+-}
+-
+ func getDMStats(poolName string, dataBlkSize uint) (uint64, uint64, uint64, error) {
+ 	out, err := exec.Command("dmsetup", "status", poolName).Output()
+ 	if err != nil {
+@@ -499,26 +290,6 @@ func getDMStats(poolName string, dataBlkSize uint) (uint64, uint64, uint64, erro
+ 	return total, free, free, nil
+ }
+ 
+-func parseDMStatus(dmStatus string) (uint64, uint64, error) {
+-	dmStatus = strings.Replace(dmStatus, "/", " ", -1)
+-	dmFields := strings.Fields(dmStatus)
+-
+-	if len(dmFields) < 8 {
+-		return 0, 0, fmt.Errorf("Invalid dmsetup status output: %s", dmStatus)
+-	}
+-
+-	used, err := strconv.ParseUint(dmFields[6], 10, 64)
+-	if err != nil {
+-		return 0, 0, err
+-	}
+-	total, err := strconv.ParseUint(dmFields[7], 10, 64)
+-	if err != nil {
+-		return 0, 0, err
+-	}
+-
+-	return used, total, nil
+-}
+-
+ // getZfstats returns ZFS mount stats using zfsutils
+ func getZfstats(poolName string) (uint64, uint64, uint64, error) {
+ 	dataset, err := zfs.GetDataset(poolName)
+diff --git a/fs/fs_test.go b/fs/fs_test.go
+index 850cf82..e9e4888 100644
+--- a/fs/fs_test.go
++++ b/fs/fs_test.go
+@@ -15,10 +15,8 @@
+ package fs
+ 
+ import (
+-	"errors"
+ 	"io/ioutil"
+ 	"os"
+-	"reflect"
+ 	"testing"
+ 	"time"
+ 
+@@ -103,294 +101,3 @@ func TestDirUsage(t *testing.T) {
+ 	as.NoError(err)
+ 	as.True(expectedSize <= size, "expected dir size to be at-least %d; got size: %d", expectedSize, size)
+ }
+-
+-var dmStatusTests = []struct {
+-	dmStatus    string
+-	used        uint64
+-	total       uint64
+-	errExpected bool
+-}{
+-	{`0 409534464 thin-pool 64085 3705/4161600 88106/3199488 - rw no_discard_passdown queue_if_no_space -`, 88106, 3199488, false},
+-	{`0 209715200 thin-pool 707 1215/524288 30282/1638400 - rw discard_passdown`, 30282, 1638400, false},
+-	{`Invalid status line`, 0, 0, false},
+-}
+-
+-func TestParseDMStatus(t *testing.T) {
+-	for _, tt := range dmStatusTests {
+-		used, total, err := parseDMStatus(tt.dmStatus)
+-		if tt.errExpected && err != nil {
+-			t.Errorf("parseDMStatus(%q) expected error", tt.dmStatus)
+-		}
+-		if used != tt.used {
+-			t.Errorf("parseDMStatus(%q) wrong used value => %q, want %q", tt.dmStatus, used, tt.used)
+-		}
+-		if total != tt.total {
+-			t.Errorf("parseDMStatus(%q) wrong total value => %q, want %q", tt.dmStatus, total, tt.total)
+-		}
+-	}
+-}
+-
+-var dmTableTests = []struct {
+-	dmTable     string
+-	major       uint
+-	minor       uint
+-	dataBlkSize uint
+-	errExpected bool
+-}{
+-	{`0 409534464 thin-pool 253:6 253:7 128 32768 1 skip_block_zeroing`, 253, 7, 128, false},
+-	{`0 409534464 thin-pool 253:6 258:9 512 32768 1 skip_block_zeroing otherstuff`, 258, 9, 512, false},
+-	{`Invalid status line`, 0, 0, 0, false},
+-}
+-
+-func TestParseDMTable(t *testing.T) {
+-	for _, tt := range dmTableTests {
+-		major, minor, dataBlkSize, err := parseDMTable(tt.dmTable)
+-		if tt.errExpected && err != nil {
+-			t.Errorf("parseDMTable(%q) expected error", tt.dmTable)
+-		}
+-		if major != tt.major {
+-			t.Errorf("parseDMTable(%q) wrong major value => %q, want %q", tt.dmTable, major, tt.major)
+-		}
+-		if minor != tt.minor {
+-			t.Errorf("parseDMTable(%q) wrong minor value => %q, want %q", tt.dmTable, minor, tt.minor)
+-		}
+-		if dataBlkSize != tt.dataBlkSize {
+-			t.Errorf("parseDMTable(%q) wrong dataBlkSize value => %q, want %q", tt.dmTable, dataBlkSize, tt.dataBlkSize)
+-		}
+-	}
+-}
+-
+-func TestAddSystemRootLabel(t *testing.T) {
+-	fsInfo := &RealFsInfo{
+-		labels: map[string]string{},
+-		partitions: map[string]partition{
+-			"/dev/mapper/vg_vagrant-lv_root": {
+-				mountpoint: "/",
+-			},
+-			"vg_vagrant-docker--pool": {
+-				mountpoint: "",
+-				fsType:     "devicemapper",
+-			},
+-		},
+-	}
+-
+-	fsInfo.addSystemRootLabel()
+-	if e, a := "/dev/mapper/vg_vagrant-lv_root", fsInfo.labels[LabelSystemRoot]; e != a {
+-		t.Errorf("expected %q, got %q", e, a)
+-	}
+-}
+-
+-type testDmsetup struct {
+-	data []byte
+-	err  error
+-}
+-
+-func (t *testDmsetup) table(poolName string) ([]byte, error) {
+-	return t.data, t.err
+-}
+-
+-func TestGetDockerDeviceMapperInfo(t *testing.T) {
+-	tests := []struct {
+-		name              string
+-		driver            string
+-		driverStatus      string
+-		dmsetupTable      string
+-		dmsetupTableError error
+-		expectedDevice    string
+-		expectedPartition *partition
+-		expectedError     bool
+-	}{
+-		{
+-			name:              "not devicemapper",
+-			driver:            "btrfs",
+-			expectedDevice:    "",
+-			expectedPartition: nil,
+-			expectedError:     false,
+-		},
+-		{
+-			name:              "error unmarshaling driver status",
+-			driver:            "devicemapper",
+-			driverStatus:      "{[[[asdf",
+-			expectedDevice:    "",
+-			expectedPartition: nil,
+-			expectedError:     true,
+-		},
+-		{
+-			name:              "loopback",
+-			driver:            "devicemapper",
+-			driverStatus:      `[["Data loop file","/var/lib/docker/devicemapper/devicemapper/data"]]`,
+-			expectedDevice:    "",
+-			expectedPartition: nil,
+-			expectedError:     false,
+-		},
+-		{
+-			name:              "missing pool name",
+-			driver:            "devicemapper",
+-			driverStatus:      `[[]]`,
+-			expectedDevice:    "",
+-			expectedPartition: nil,
+-			expectedError:     true,
+-		},
+-		{
+-			name:              "error invoking dmsetup",
+-			driver:            "devicemapper",
+-			driverStatus:      `[["Pool Name", "vg_vagrant-docker--pool"]]`,
+-			dmsetupTableError: errors.New("foo"),
+-			expectedDevice:    "",
+-			expectedPartition: nil,
+-			expectedError:     true,
+-		},
+-		{
+-			name:              "unable to parse dmsetup table",
+-			driver:            "devicemapper",
+-			driverStatus:      `[["Pool Name", "vg_vagrant-docker--pool"]]`,
+-			dmsetupTable:      "no data here!",
+-			expectedDevice:    "",
+-			expectedPartition: nil,
+-			expectedError:     true,
+-		},
+-		{
+-			name:           "happy path",
+-			driver:         "devicemapper",
+-			driverStatus:   `[["Pool Name", "vg_vagrant-docker--pool"]]`,
+-			dmsetupTable:   "0 53870592 thin-pool 253:2 253:3 1024 0 1 skip_block_zeroing",
+-			expectedDevice: "vg_vagrant-docker--pool",
+-			expectedPartition: &partition{
+-				fsType:    "devicemapper",
+-				major:     253,
+-				minor:     3,
+-				blockSize: 1024,
+-			},
+-			expectedError: false,
+-		},
+-	}
+-
+-	for _, tt := range tests {
+-		fsInfo := &RealFsInfo{
+-			dmsetup: &testDmsetup{
+-				data: []byte(tt.dmsetupTable),
+-			},
+-		}
+-
+-		dockerInfo := map[string]string{
+-			"Driver":       tt.driver,
+-			"DriverStatus": tt.driverStatus,
+-		}
+-
+-		device, partition, err := fsInfo.getDockerDeviceMapperInfo(dockerInfo)
+-
+-		if tt.expectedError && err == nil {
+-			t.Errorf("%s: expected error but got nil", tt.name)
+-			continue
+-		}
+-		if !tt.expectedError && err != nil {
+-			t.Errorf("%s: unexpected error: %v", tt.name, err)
+-			continue
+-		}
+-
+-		if e, a := tt.expectedDevice, device; e != a {
+-			t.Errorf("%s: device: expected %q, got %q", tt.name, e, a)
+-		}
+-
+-		if e, a := tt.expectedPartition, partition; !reflect.DeepEqual(e, a) {
+-			t.Errorf("%s: partition: expected %#v, got %#v", tt.name, e, a)
+-		}
+-	}
+-}
+-
+-func TestAddDockerImagesLabel(t *testing.T) {
+-	tests := []struct {
+-		name                           string
+-		driver                         string
+-		driverStatus                   string
+-		dmsetupTable                   string
+-		getDockerDeviceMapperInfoError error
+-		partitions                     map[string]partition
+-		expectedDockerDevice           string
+-		expectedPartition              *partition
+-	}{
+-		{
+-			name:         "devicemapper, not loopback",
+-			driver:       "devicemapper",
+-			driverStatus: `[["Pool Name", "vg_vagrant-docker--pool"]]`,
+-			dmsetupTable: "0 53870592 thin-pool 253:2 253:3 1024 0 1 skip_block_zeroing",
+-			partitions: map[string]partition{
+-				"/dev/mapper/vg_vagrant-lv_root": {
+-					mountpoint: "/",
+-					fsType:     "devicemapper",
+-				},
+-			},
+-			expectedDockerDevice: "vg_vagrant-docker--pool",
+-			expectedPartition: &partition{
+-				fsType:    "devicemapper",
+-				major:     253,
+-				minor:     3,
+-				blockSize: 1024,
+-			},
+-		},
+-		{
+-			name:         "devicemapper, loopback on non-root partition",
+-			driver:       "devicemapper",
+-			driverStatus: `[["Data loop file","/var/lib/docker/devicemapper/devicemapper/data"]]`,
+-			partitions: map[string]partition{
+-				"/dev/mapper/vg_vagrant-lv_root": {
+-					mountpoint: "/",
+-					fsType:     "devicemapper",
+-				},
+-				"/dev/sdb1": {
+-					mountpoint: "/var/lib/docker/devicemapper",
+-				},
+-			},
+-			expectedDockerDevice: "/dev/sdb1",
+-		},
+-		{
+-			name: "multiple mounts - innermost check",
+-			partitions: map[string]partition{
+-				"/dev/sda1": {
+-					mountpoint: "/",
+-					fsType:     "ext4",
+-				},
+-				"/dev/sdb1": {
+-					mountpoint: "/var/lib/docker",
+-					fsType:     "ext4",
+-				},
+-				"/dev/sdb2": {
+-					mountpoint: "/var/lib/docker/btrfs",
+-					fsType:     "btrfs",
+-				},
+-			},
+-			expectedDockerDevice: "/dev/sdb2",
+-		},
+-	}
+-
+-	for _, tt := range tests {
+-		fsInfo := &RealFsInfo{
+-			labels:     map[string]string{},
+-			partitions: tt.partitions,
+-			dmsetup: &testDmsetup{
+-				data: []byte(tt.dmsetupTable),
+-			},
+-		}
+-
+-		context := Context{
+-			DockerRoot: "/var/lib/docker",
+-			DockerInfo: map[string]string{
+-				"Driver":       tt.driver,
+-				"DriverStatus": tt.driverStatus,
+-			},
+-		}
+-
+-		fsInfo.addDockerImagesLabel(context)
+-
+-		if e, a := tt.expectedDockerDevice, fsInfo.labels[LabelDockerImages]; e != a {
+-			t.Errorf("%s: docker device: expected %q, got %q", tt.name, e, a)
+-		}
+-
+-		if tt.expectedPartition == nil {
+-			continue
+-		}
+-		if e, a := *tt.expectedPartition, fsInfo.partitions[tt.expectedDockerDevice]; !reflect.DeepEqual(e, a) {
+-			t.Errorf("%s: docker partition: expected %#v, got %#v", tt.name, e, a)
+-		}
+-	}
+-}
+diff --git a/fs/mount_helper.go b/fs/mount_helper.go
+new file mode 100644
+index 0000000..b1ca52f
+--- /dev/null
++++ b/fs/mount_helper.go
+@@ -0,0 +1,32 @@
++// Copyright 2016 Google Inc. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++// +build linux
++package fs
++
++import (
++	dockerMountInfo "github.com/docker/docker/pkg/mount"
++)
++
++type mountInfoClient interface {
++	GetMounts() ([]*dockerMountInfo.Info, error)
++}
++
++type defaultMountInfoClient struct{}
++
++func (*defaultMountInfoClient) GetMounts() ([]*dockerMountInfo.Info, error) {
++	return dockerMountInfo.GetMounts()
++}
++
++var _ mountInfoClient = &defaultMountInfoClient{}
+diff --git a/fs/partition_cache.go b/fs/partition_cache.go
+new file mode 100644
+index 0000000..45248e1
+--- /dev/null
++++ b/fs/partition_cache.go
+@@ -0,0 +1,342 @@
++// Copyright 2016 Google Inc. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++// +build linux
++package fs
++
++import (
++	"encoding/json"
++	"fmt"
++	"github.com/golang/glog"
++	"path"
++	"path/filepath"
++	"strings"
++	"sync"
++)
++
++const (
++	LabelSystemRoot   = "root"
++	LabelDockerImages = "docker-images"
++)
++
++type RealPartitionCache struct {
++	dmsetup   dmsetupClient
++	mountInfo mountInfoClient
++	// Docker configuration
++	context Context
++	// Map from block device path to partition information.
++	partitions map[string]partition
++	// Labels are intent-specific tags that are auto-detected.
++	labels map[string]string
++	// For operations on partitions and labels
++	lock sync.Mutex
++}
++
++func newPartitionCache(context Context, dmsetup dmsetupClient, mountInfo mountInfoClient) PartitionCache {
++	partitionCache := &RealPartitionCache{
++		context:    context,
++		dmsetup:    dmsetup,
++		mountInfo:  mountInfo,
++		partitions: make(map[string]partition),
++		labels:     make(map[string]string),
++	}
++	return partitionCache
++}
++
++func NewPartitionCache(context Context) PartitionCache {
++	return newPartitionCache(context, &defaultDmsetupClient{}, &defaultMountInfoClient{})
++}
++
++func (self *RealPartitionCache) updateCache(labels map[string]string, partitions map[string]partition) {
++	self.lock.Lock()
++	defer self.lock.Unlock()
++	self.labels = labels
++	self.partitions = partitions
++}
++
++func (self *RealPartitionCache) Clear() {
++	self.updateCache(make(map[string]string), make(map[string]partition))
++}
++
++func (self *RealPartitionCache) Refresh() error {
++	partitions := make(map[string]partition)
++	labels := make(map[string]string)
++
++	supportedFsType := map[string]bool{
++		// all ext systems are checked through prefix.
++		"btrfs": true,
++		"xfs":   true,
++		"zfs":   true,
++	}
++
++	mounts, err := self.mountInfo.GetMounts()
++	if err != nil {
++		return err
++	}
++	for _, mount := range mounts {
++		var Fstype string
++		if !strings.HasPrefix(mount.Fstype, "ext") && !supportedFsType[mount.Fstype] {
++			continue
++		}
++		// Avoid bind mounts.
++		if _, ok := partitions[mount.Source]; ok {
++			continue
++		}
++		if mount.Fstype == "zfs" {
++			Fstype = mount.Fstype // REVIEW: Is this correct?
++		}
++		partitions[mount.Source] = partition{
++			fsType:     Fstype,
++			mountpoint: mount.Mountpoint,
++			major:      uint(mount.Major),
++			minor:      uint(mount.Minor),
++		}
++	}
++
++	addDockerImagesLabel(self.context, self.dmsetup, labels, partitions)
++	addSystemRootLabel(labels, partitions)
++
++	self.updateCache(labels, partitions)
++	return nil
++}
++
++func (self *RealPartitionCache) ApplyOverPartitions(f func(d string, p partition) error) error {
++	if len(self.partitions) == 0 {
++		glog.Infof("Partition cache is empty: updating")
++		err := self.Refresh()
++		if err != nil {
++			return err
++		}
++	}
++
++	for device, partition := range self.partitions {
++		err := f(device, partition)
++		if err != nil {
++			return err
++		}
++	}
++
++	return nil
++}
++
++func (self *RealPartitionCache) ApplyOverLabels(f func(l string, d string) error) error {
++	if len(self.labels) == 0 {
++		glog.Infof("Partition cache is empty: updating")
++		err := self.Refresh()
++		if err != nil {
++			return err
++		}
++	}
++
++	for label, device := range self.labels {
++		err := f(label, device)
++		if err != nil {
++			return err
++		}
++	}
++
++	return nil
++}
++
++func (self *RealPartitionCache) PartitionForDevice(device string) (partition, error) {
++	p, ok := self.partitions[device]
++	if ok {
++		return p, nil
++	}
++
++	glog.Infof("Partition cache miss for device %q, refreshing partition cache", device)
++	err := self.Refresh()
++	if err != nil {
++		return partition{}, err
++	}
++
++	p, ok = self.partitions[device]
++	if ok {
++		return p, nil
++	}
++
++	return partition{}, fmt.Errorf("No partition for device %s", device)
++}
++
++func (self *RealPartitionCache) DeviceInfoForMajorMinor(major uint, minor uint) (*DeviceInfo, error) {
++	var ret *DeviceInfo = nil
++
++	err := self.ApplyOverPartitions(func(device string, partition partition) error {
++		if partition.major == major && partition.minor == minor {
++			ret = &DeviceInfo{
++				Device: device,
++				Major:  major,
++				Minor:  minor,
++			}
++		}
++		return nil
++	})
++
++	if err != nil {
++		return nil, err
++	}
++
++	if ret == nil {
++		return nil, fmt.Errorf("could not find device with major: %d, minor: %d in partition cache", major, minor)
++	}
++
++	return ret, nil
++}
++
++func (self *RealPartitionCache) DeviceNameForLabel(label string) (string, error) {
++	d, ok := self.labels[label]
++	if ok {
++		return d, nil
++	}
++
++	glog.Infof("Partition cache miss for label %q, refreshing partition cache", label)
++	err := self.Refresh()
++	if err != nil {
++		return "", err
++	}
++
++	d, ok = self.labels[label]
++	if ok {
++		return d, nil
++	}
++
++	return "", fmt.Errorf("No device for label %s", label)
++}
++
++// addSystemRootLabel attempts to determine which device contains the mount for /.
++func addSystemRootLabel(labels map[string]string, partitions map[string]partition) {
++	for src, p := range partitions {
++		if p.mountpoint == "/" {
++			if _, ok := labels[LabelSystemRoot]; !ok {
++				labels[LabelSystemRoot] = src
++			}
++		}
++	}
++}
++
++// addDockerImagesLabel attempts to determine which device contains the mount for docker images.
++func addDockerImagesLabel(context Context, dmsetup dmsetupClient, labels map[string]string, partitions map[string]partition) {
++	dockerDev, dockerPartition, err := getDockerDeviceMapperInfo(context.DockerInfo, dmsetup)
++	if err != nil {
++		glog.Warningf("Could not get Docker devicemapper device: %v", err)
++	}
++	if len(dockerDev) > 0 && dockerPartition != nil {
++		partitions[dockerDev] = *dockerPartition
++		labels[LabelDockerImages] = dockerDev
++	} else {
++		dockerPaths := getDockerImagePaths(context)
++
++		for src, p := range partitions {
++			updateDockerImagesPath(src, p.mountpoint, dockerPaths, labels, partitions)
++		}
++	}
++}
++
++// Generate a list of possible mount points for docker image management from the docker root directory.
++// Right now, we look for each type of supported graph driver directories, but we can do better by parsing
++// some of the context from `docker info`.
++func getDockerImagePaths(context Context) []string {
++	// TODO(rjnagal): Detect docker root and graphdriver directories from docker info.
++	dockerRoot := context.DockerRoot
++	dockerImagePaths := []string{}
++	for _, dir := range []string{"devicemapper", "btrfs", "aufs", "overlay", "zfs"} {
++		dockerImagePaths = append(dockerImagePaths, path.Join(dockerRoot, dir))
++	}
++	for dockerRoot != "/" && dockerRoot != "." {
++		dockerImagePaths = append(dockerImagePaths, dockerRoot)
++		dockerRoot = filepath.Dir(dockerRoot)
++	}
++	dockerImagePaths = append(dockerImagePaths, "/")
++	return dockerImagePaths
++}
++
++// This method compares the mountpoint with possible docker image mount points. If a match is found,
++// docker images label is added to the partition.
++func updateDockerImagesPath(source string, mountpoint string, dockerImagePaths []string, labels map[string]string, partitions map[string]partition) {
++	for _, v := range dockerImagePaths {
++		if v == mountpoint {
++			if i, ok := labels[LabelDockerImages]; ok {
++				// pick the innermost mountpoint.
++				mnt := partitions[i].mountpoint
++				if len(mnt) < len(mountpoint) {
++					labels[LabelDockerImages] = source
++				}
++			} else {
++				labels[LabelDockerImages] = source
++			}
++		}
++	}
++}
++
++// Devicemapper thin provisioning is detailed at
++// https://www.kernel.org/doc/Documentation/device-mapper/thin-provisioning.txt
++func dockerDMDevice(driverStatus [][]string, dmsetup dmsetupClient) (string, uint, uint, uint, error) {
++	poolName := dockerStatusValue(driverStatus, "Pool Name")
++	if len(poolName) == 0 {
++		return "", 0, 0, 0, fmt.Errorf("Could not get dm pool name")
++	}
++
++	out, err := dmsetup.table(poolName)
++	if err != nil {
++		return "", 0, 0, 0, err
++	}
++
++	major, minor, dataBlkSize, err := parseDMTable(string(out))
++	if err != nil {
++		return "", 0, 0, 0, err
++	}
++
++	return poolName, major, minor, dataBlkSize, nil
++}
++
++// getDockerDeviceMapperInfo returns information about the devicemapper device and "partition" if
++// docker is using devicemapper for its storage driver. If a loopback device is being used, don't
++// return any information or error, as we want to report based on the actual partition where the
++// loopback file resides, instead of the loopback file itself.
++func getDockerDeviceMapperInfo(dockerInfo map[string]string, dmsetup dmsetupClient) (string, *partition, error) {
++	if storageDriver, ok := dockerInfo["Driver"]; ok && storageDriver != DeviceMapper.String() {
++		return "", nil, nil
++	}
++
++	var driverStatus [][]string
++	if err := json.Unmarshal([]byte(dockerInfo["DriverStatus"]), &driverStatus); err != nil {
++		return "", nil, err
++	}
++
++	dataLoopFile := dockerStatusValue(driverStatus, "Data loop file")
++	if len(dataLoopFile) > 0 {
++		return "", nil, nil
++	}
++
++	dev, major, minor, blockSize, err := dockerDMDevice(driverStatus, dmsetup)
++	if err != nil {
++		return "", nil, err
++	}
++
++	return dev, &partition{
++		fsType:    DeviceMapper.String(),
++		major:     major,
++		minor:     minor,
++		blockSize: blockSize,
++	}, nil
++}
++
++func dockerStatusValue(status [][]string, target string) string {
++	for _, v := range status {
++		if len(v) == 2 && strings.ToLower(v[0]) == strings.ToLower(target) {
++			return v[1]
++		}
++	}
++	return ""
++}
+diff --git a/fs/partition_cache_test.go b/fs/partition_cache_test.go
+new file mode 100644
+index 0000000..b92ea58
+--- /dev/null
++++ b/fs/partition_cache_test.go
+@@ -0,0 +1,487 @@
++// Copyright 2016 Google Inc. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++package fs
++
++import (
++	"errors"
++	"fmt"
++	"github.com/stretchr/testify/assert"
++	"reflect"
++	"sync"
++	"sync/atomic"
++	"testing"
++
++	dockerMountInfo "github.com/docker/docker/pkg/mount"
++)
++
++type testMountInfoClient struct {
++	Calls  int
++	mounts []*dockerMountInfo.Info
++}
++
++func (self *testMountInfoClient) GetMounts() ([]*dockerMountInfo.Info, error) {
++	self.Calls += 1
++	if len(self.mounts) == 0 {
++		return nil, fmt.Errorf("No test mounts!")
++	}
++	return self.mounts, nil
++}
++
++func TestBaseCacheOperations(t *testing.T) {
++	as := assert.New(t)
++
++	// Prepare dummy mounts
++	mounts := []*dockerMountInfo.Info{
++		&dockerMountInfo.Info{
++			Major:      1,
++			Minor:      11,
++			Source:     "/dev/sda1",
++			Mountpoint: "/",
++			Fstype:     "ext4",
++		},
++		&dockerMountInfo.Info{
++			Major:      2,
++			Minor:      22,
++			Source:     "/dev/sdb1",
++			Mountpoint: "/var/lib/docker",
++			Fstype:     "xfs",
++		},
++		&dockerMountInfo.Info{
++			Major:      3,
++			Minor:      33,
++			Mountpoint: "/tmp",
++			Fstype:     "tmpfs",
++		},
++	}
++
++	mountInfoClient := &testMountInfoClient{
++		mounts: mounts,
++	}
++
++	partitionCache := newPartitionCache(Context{
++		DockerRoot: "/var/lib/docker",
++		DockerInfo: make(map[string]string),
++	}, &testDmsetup{}, mountInfoClient)
++
++	// PartitionForDevice should work
++	p1, err := partitionCache.PartitionForDevice("/dev/sda1")
++	as.NoError(err)
++	as.Equal(uint(1), p1.major)
++	as.Equal(uint(11), p1.minor)
++	as.Equal("/", p1.mountpoint)
++
++	p2, err := partitionCache.PartitionForDevice("/dev/sdb1")
++	as.NoError(err)
++	as.Equal(uint(2), p2.major)
++	as.Equal(uint(22), p2.minor)
++	as.Equal("/var/lib/docker", p2.mountpoint)
++
++	// DeviceInfoForMajorMinor should work as well
++	d1, err := partitionCache.DeviceInfoForMajorMinor(1, 11)
++	as.NoError(err)
++	as.Equal("/dev/sda1", d1.Device)
++	as.Equal(uint(1), d1.Major)
++	as.Equal(uint(11), d1.Minor)
++
++	d2, err := partitionCache.DeviceInfoForMajorMinor(2, 22)
++	as.NoError(err)
++	as.Equal("/dev/sdb1", d2.Device)
++
++	// tmpfs should be ignored
++	_, err = partitionCache.DeviceInfoForMajorMinor(3, 33)
++	as.Error(err)
++
++	// Check labels
++	d3, err := partitionCache.DeviceNameForLabel(LabelSystemRoot)
++	as.NoError(err)
++	as.Equal("/dev/sda1", d3)
++
++	d4, err := partitionCache.DeviceNameForLabel(LabelDockerImages)
++	as.NoError(err)
++	as.Equal("/dev/sdb1", d4)
++
++	// Test that the cache refreshes automatically when data is missing
++	var n int
++
++	baseCalls := mountInfoClient.Calls
++
++	partitionCache.Clear()
++	n = 0
++	partitionCache.ApplyOverPartitions(func(d string, p partition) error {
++		n += 1
++		return nil
++	})
++	as.Equal(2, n)
++	as.Equal(baseCalls+1, mountInfoClient.Calls)
++
++	partitionCache.Clear()
++	n = 0
++	partitionCache.ApplyOverLabels(func(l string, d string) error {
++		n += 1
++		return nil
++	})
++	as.Equal(2, n)
++	as.Equal(baseCalls+2, mountInfoClient.Calls)
++
++	partitionCache.Clear()
++	p, err := partitionCache.PartitionForDevice("/dev/sda1")
++	as.NoError(err)
++	as.Equal("/", p.mountpoint)
++	as.Equal(baseCalls+3, mountInfoClient.Calls)
++
++	partitionCache.Clear()
++	i, err := partitionCache.DeviceInfoForMajorMinor(1, 11)
++	as.NoError(err)
++	as.Equal("/dev/sda1", i.Device)
++	as.Equal(baseCalls+4, mountInfoClient.Calls)
++
++	partitionCache.Clear()
++	d, err := partitionCache.DeviceNameForLabel(LabelSystemRoot)
++	as.NoError(err)
++	as.Equal("/dev/sda1", d)
++	as.Equal(baseCalls+5, mountInfoClient.Calls)
++}
++
++func TestDeviceMapperLabelling(t *testing.T) {
++	as := assert.New(t)
++	mounts := []*dockerMountInfo.Info{
++		&dockerMountInfo.Info{
++			Major:      1,
++			Minor:      11,
++			Source:     "/dev/sda1",
++			Mountpoint: "/",
++			Fstype:     "ext4",
++		},
++	}
++
++	dockerInfo := map[string]string{
++		"Driver":       "devicemapper",
++		"DriverStatus": "[[\"Pool Name\", \"thin-pool\"]]",
++	}
++
++	partitionCache := newPartitionCache(Context{
++		DockerRoot: "/var/lib/docker",
++		DockerInfo: dockerInfo,
++	}, &testDmsetup{
++		data: []byte("0 409534464 thin-pool 253:6 2:22 128 32768 1 skip_block_zeroing"),
++		err:  nil,
++	}, &testMountInfoClient{
++		mounts: mounts,
++	})
++
++	// Check that we get the right devices back via major / minor
++	d1, err := partitionCache.DeviceInfoForMajorMinor(2, 22)
++	as.NoError(err)
++	as.Equal("thin-pool", d1.Device)
++
++	d2, err := partitionCache.DeviceInfoForMajorMinor(1, 11)
++	as.NoError(err)
++	as.Equal("/dev/sda1", d2.Device)
++
++	// Check that the Docker images label is properly applied
++	d3, err := partitionCache.DeviceNameForLabel(LabelDockerImages)
++	as.NoError(err)
++	as.Equal("thin-pool", d3)
++
++	// Verify that the partition exists as well
++	p, err := partitionCache.PartitionForDevice("thin-pool")
++	as.NoError(err)
++	as.Equal("devicemapper", p.fsType)
++	as.Equal(uint(128), p.blockSize)
++}
++
++type raceMounts struct {
++	i int32
++}
++
++func (self *raceMounts) GetMounts() ([]*dockerMountInfo.Info, error) {
++	i := atomic.AddInt32(&self.i, 1)
++
++	mounts := make([]*dockerMountInfo.Info, i)
++
++	var j int32
++	for j = 0; j < i; j++ {
++		mounts[j] = &dockerMountInfo.Info{
++			Major:      int(j),
++			Minor:      int(j * 10),
++			Source:     fmt.Sprintf("%d", i),
++			Mountpoint: fmt.Sprintf("%d", j),
++			Fstype:     "ext4",
++		}
++	}
++
++	return mounts, nil
++}
++
++func TestPartitionCacheRefreshRaces(t *testing.T) {
++	as := assert.New(t)
++	n := 100
++
++	partitionCache := newPartitionCache(Context{
++		DockerRoot: "/var/lib/docker",
++		DockerInfo: make(map[string]string),
++	}, &testDmsetup{}, &raceMounts{i: 0})
++
++	wg := &sync.WaitGroup{}
++	wg.Add(n)
++
++	for i := 0; i < n; i++ {
++		go func() {
++			defer wg.Done()
++			partitionCache.Refresh()
++		}()
++	}
++
++	wg.Wait()
++
++	// We can largely rely on the data race detector to throw an error here,
++	// but it's still worth checking that all the partitions that were added
++	// via the same update (by checking the device, which we set to i.
++	var last string
++	err := partitionCache.ApplyOverPartitions(func(d string, _ partition) error {
++		if len(last) == 0 {
++			last = d
++			return nil
++		}
++
++		if last != d {
++			return fmt.Errorf("Race (mismatched sources): %s, %s", last, d)
++		}
++
++		return nil
++	})
++
++	as.NoError(err)
++}
++
++func TestAddSystemRootLabel(t *testing.T) {
++	labels := map[string]string{}
++	partitions := map[string]partition{
++		"/dev/mapper/vg_vagrant-lv_root": {
++			mountpoint: "/",
++		},
++		"vg_vagrant-docker--pool": {
++			mountpoint: "",
++			fsType:     "devicemapper",
++		},
++	}
++
++	addSystemRootLabel(labels, partitions)
++	if e, a := "/dev/mapper/vg_vagrant-lv_root", labels[LabelSystemRoot]; e != a {
++		t.Errorf("expected %q, got %q", e, a)
++	}
++}
++
++func TestAddDockerImagesLabel(t *testing.T) {
++	tests := []struct {
++		name                           string
++		driver                         string
++		driverStatus                   string
++		dmsetupTable                   string
++		getDockerDeviceMapperInfoError error
++		partitions                     map[string]partition
++		expectedDockerDevice           string
++		expectedPartition              *partition
++	}{
++		{
++			name:         "devicemapper, not loopback",
++			driver:       "devicemapper",
++			driverStatus: `[["Pool Name", "vg_vagrant-docker--pool"]]`,
++			dmsetupTable: "0 53870592 thin-pool 253:2 253:3 1024 0 1 skip_block_zeroing",
++			partitions: map[string]partition{
++				"/dev/mapper/vg_vagrant-lv_root": {
++					mountpoint: "/",
++					fsType:     "devicemapper",
++				},
++			},
++			expectedDockerDevice: "vg_vagrant-docker--pool",
++			expectedPartition: &partition{
++				fsType:    "devicemapper",
++				major:     253,
++				minor:     3,
++				blockSize: 1024,
++			},
++		},
++		{
++			name:         "devicemapper, loopback on non-root partition",
++			driver:       "devicemapper",
++			driverStatus: `[["Data loop file","/var/lib/docker/devicemapper/devicemapper/data"]]`,
++			partitions: map[string]partition{
++				"/dev/mapper/vg_vagrant-lv_root": {
++					mountpoint: "/",
++					fsType:     "devicemapper",
++				},
++				"/dev/sdb1": {
++					mountpoint: "/var/lib/docker/devicemapper",
++				},
++			},
++			expectedDockerDevice: "/dev/sdb1",
++		},
++		{
++			name: "multiple mounts - innermost check",
++			partitions: map[string]partition{
++				"/dev/sda1": {
++					mountpoint: "/",
++					fsType:     "ext4",
++				},
++				"/dev/sdb1": {
++					mountpoint: "/var/lib/docker",
++					fsType:     "ext4",
++				},
++				"/dev/sdb2": {
++					mountpoint: "/var/lib/docker/btrfs",
++					fsType:     "btrfs",
++				},
++			},
++			expectedDockerDevice: "/dev/sdb2",
++		},
++	}
++
++	for _, tt := range tests {
++		dmsetup := &testDmsetup{
++			data: []byte(tt.dmsetupTable),
++		}
++		partitions := tt.partitions
++		labels := map[string]string{}
++
++		context := Context{
++			DockerRoot: "/var/lib/docker",
++			DockerInfo: map[string]string{
++				"Driver":       tt.driver,
++				"DriverStatus": tt.driverStatus,
++			},
++		}
++
++		addDockerImagesLabel(context, dmsetup, labels, partitions)
++
++		if e, a := tt.expectedDockerDevice, labels[LabelDockerImages]; e != a {
++			t.Errorf("%s: docker device: expected %q, got %q", tt.name, e, a)
++		}
++
++		if tt.expectedPartition == nil {
++			continue
++		}
++		if e, a := *tt.expectedPartition, partitions[tt.expectedDockerDevice]; !reflect.DeepEqual(e, a) {
++			t.Errorf("%s: docker partition: expected %#v, got %#v", tt.name, e, a)
++		}
++	}
++}
++
++func TestGetDockerDeviceMapperInfo(t *testing.T) {
++	tests := []struct {
++		name              string
++		driver            string
++		driverStatus      string
++		dmsetupTable      string
++		dmsetupTableError error
++		expectedDevice    string
++		expectedPartition *partition
++		expectedError     bool
++	}{
++		{
++			name:              "not devicemapper",
++			driver:            "btrfs",
++			expectedDevice:    "",
++			expectedPartition: nil,
++			expectedError:     false,
++		},
++		{
++			name:              "error unmarshaling driver status",
++			driver:            "devicemapper",
++			driverStatus:      "{[[[asdf",
++			expectedDevice:    "",
++			expectedPartition: nil,
++			expectedError:     true,
++		},
++		{
++			name:              "loopback",
++			driver:            "devicemapper",
++			driverStatus:      `[["Data loop file","/var/lib/docker/devicemapper/devicemapper/data"]]`,
++			expectedDevice:    "",
++			expectedPartition: nil,
++			expectedError:     false,
++		},
++		{
++			name:              "missing pool name",
++			driver:            "devicemapper",
++			driverStatus:      `[[]]`,
++			expectedDevice:    "",
++			expectedPartition: nil,
++			expectedError:     true,
++		},
++		{
++			name:              "error invoking dmsetup",
++			driver:            "devicemapper",
++			driverStatus:      `[["Pool Name", "vg_vagrant-docker--pool"]]`,
++			dmsetupTableError: errors.New("foo"),
++			expectedDevice:    "",
++			expectedPartition: nil,
++			expectedError:     true,
++		},
++		{
++			name:              "unable to parse dmsetup table",
++			driver:            "devicemapper",
++			driverStatus:      `[["Pool Name", "vg_vagrant-docker--pool"]]`,
++			dmsetupTable:      "no data here!",
++			expectedDevice:    "",
++			expectedPartition: nil,
++			expectedError:     true,
++		},
++		{
++			name:           "happy path",
++			driver:         "devicemapper",
++			driverStatus:   `[["Pool Name", "vg_vagrant-docker--pool"]]`,
++			dmsetupTable:   "0 53870592 thin-pool 253:2 253:3 1024 0 1 skip_block_zeroing",
++			expectedDevice: "vg_vagrant-docker--pool",
++			expectedPartition: &partition{
++				fsType:    "devicemapper",
++				major:     253,
++				minor:     3,
++				blockSize: 1024,
++			},
++			expectedError: false,
++		},
++	}
++
++	for _, tt := range tests {
++		dmsetup := &testDmsetup{
++			data: []byte(tt.dmsetupTable),
++		}
++
++		dockerInfo := map[string]string{
++			"Driver":       tt.driver,
++			"DriverStatus": tt.driverStatus,
++		}
++
++		device, partition, err := getDockerDeviceMapperInfo(dockerInfo, dmsetup)
++
++		if tt.expectedError && err == nil {
++			t.Errorf("%s: expected error but got nil", tt.name)
++			continue
++		}
++		if !tt.expectedError && err != nil {
++			t.Errorf("%s: unexpected error: %v", tt.name, err)
++			continue
++		}
++
++		if e, a := tt.expectedDevice, device; e != a {
++			t.Errorf("%s: device: expected %q, got %q", tt.name, e, a)
++		}
++
++		if e, a := tt.expectedPartition, partition; !reflect.DeepEqual(e, a) {
++			t.Errorf("%s: partition: expected %#v, got %#v", tt.name, e, a)
++		}
++	}
++}
+diff --git a/fs/types.go b/fs/types.go
+index 317af49..17bc5f1 100644
+--- a/fs/types.go
++++ b/fs/types.go
+@@ -16,6 +16,14 @@ package fs
+ 
+ import "time"
+ 
++type partition struct {
++	mountpoint string
++	major      uint
++	minor      uint
++	fsType     string
++	blockSize  uint
++}
++
+ type DeviceInfo struct {
+ 	Device string
+ 	Major  uint
+@@ -60,6 +68,9 @@ type DiskStats struct {
+ }
+ 
+ type FsInfo interface {
++	// Refreshes the cache
++	RefreshCache()
++
+ 	// Returns capacity and free space, in bytes, of all the ext2, ext3, ext4 filesystems on the host.
+ 	GetGlobalFsInfo() ([]Fs, error)
+ 
+@@ -81,3 +92,13 @@ type FsInfo interface {
+ 	// Returns the mountpoint associated with a particular device.
+ 	GetMountpointForDevice(device string) (string, error)
+ }
++
++type PartitionCache interface {
++	Refresh() error
++	Clear()
++	PartitionForDevice(device string) (partition, error)
++	DeviceInfoForMajorMinor(major uint, minor uint) (*DeviceInfo, error)
++	ApplyOverPartitions(f func(device string, p partition) error) error
++	DeviceNameForLabel(label string) (string, error)
++	ApplyOverLabels(f func(label string, device string) error) error
++}
+-- 
+2.7.4
+

--- a/patches/0015-Periodically-refresh-PartitionCache.patch
+++ b/patches/0015-Periodically-refresh-PartitionCache.patch
@@ -1,0 +1,71 @@
+From ccd8aa1323b75e6f3cefacde7ed6cece6457a70b Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Fri, 8 Apr 2016 22:19:20 +0200
+Subject: [PATCH] Periodically refresh PartitionCache
+
+This complements the addition of the PartitionCache with a periodic
+refresh, which ensures information doesn't stale for too long.
+
+This is useful considering some methods of PartitionCache
+(ApplyOverLabels and ApplyOverPartitions) can't know whether they
+returned the data the receiver cared about or not and therefore can't
+know to refresh the cache.
+---
+ manager/manager.go | 24 ++++++++++++++++++++++--
+ 1 file changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/manager/manager.go b/manager/manager.go
+index aa6d186..04ecc99 100644
+--- a/manager/manager.go
++++ b/manager/manager.go
+@@ -148,7 +148,7 @@ func New(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, maxHousekeepingIn
+ 
+ 	newManager := &manager{
+ 		containers:               make(map[namespacedContainerName]*containerData),
+-		quitChannels:             make([]chan error, 0, 2),
++		quitChannels:             make([]chan error, 0, 3),
+ 		memoryCache:              memoryCache,
+ 		fsInfo:                   fsInfo,
+ 		cadvisorContainer:        selfContainer,
+@@ -254,6 +254,11 @@ func (self *manager) Start() error {
+ 	self.quitChannels = append(self.quitChannels, quitGlobalHousekeeping)
+ 	go self.globalHousekeeping(quitGlobalHousekeeping)
+ 
++	// Update FS info to prevent it from going stale
++	quitFsInfoCacheManager := make(chan error)
++	self.quitChannels = append(self.quitChannels, quitFsInfoCacheManager)
++	go self.fsInfoCacheRefreshLoop(quitFsInfoCacheManager)
++
+ 	return nil
+ }
+ 
+@@ -269,10 +274,25 @@ func (self *manager) Stop() error {
+ 			return err
+ 		}
+ 	}
+-	self.quitChannels = make([]chan error, 0, 2)
++	self.quitChannels = make([]chan error, 0, 3)
+ 	return nil
+ }
+ 
++func (self *manager) fsInfoCacheRefreshLoop(quit chan error) {
++	ticker := time.Tick(1 * time.Minute)
++
++	for {
++		select {
++		case <-ticker:
++			self.fsInfo.RefreshCache()
++		case <-quit:
++			quit <- nil
++			glog.Infof("Exiting fsInfoCacheRefreshLoop")
++			return
++		}
++	}
++}
++
+ func (self *manager) globalHousekeeping(quit chan error) {
+ 	// Long housekeeping is either 100ms or half of the housekeeping interval.
+ 	longHousekeeping := 100 * time.Millisecond
+-- 
+2.7.4
+

--- a/patches/0016-fsHandler-support-mounts-df-and-skipped-devices.patch
+++ b/patches/0016-fsHandler-support-mounts-df-and-skipped-devices.patch
@@ -1,0 +1,1064 @@
+From adf36419085a4e3030ccb28e38f0900900369e6e Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Fri, 8 Apr 2016 16:28:57 +0200
+Subject: [PATCH] fsHandler: support mounts, df, and skipped devices
+
+This makes 3 changes to fsHandler:
+
+- First, it adds support for container mounts (i.e. we can report on an
+  arbitrary number of directories, not just 2).
+- Second, it adds a flag that allows the user to choose between `du` for
+  accurate (but somewhat expensive) disk usgae reporting and `df` for
+  faster-but-coarser FS-level reporting (of course, FS-level metrics
+  don't account for multiple containers using the same volume).
+- Third, it adds a flag that allows the user to submit a regex of
+  devices to be ignored when reporting usage stats.
+---
+ container/docker/fsHandler.go      | 240 +++++++++++++++++++++-----
+ container/docker/fsHandler_test.go | 333 +++++++++++++++++++++++++++++++++++++
+ container/docker/handler.go        | 106 ++++++------
+ container/raw/handler.go           |   4 +-
+ fs/fs.go                           | 114 ++++++++-----
+ fs/types.go                        |   7 +-
+ manager/machine.go                 |   2 +-
+ 7 files changed, 671 insertions(+), 135 deletions(-)
+ create mode 100644 container/docker/fsHandler_test.go
+
+diff --git a/container/docker/fsHandler.go b/container/docker/fsHandler.go
+index c5b406a..3a5b5e2 100644
+--- a/container/docker/fsHandler.go
++++ b/container/docker/fsHandler.go
+@@ -16,6 +16,10 @@
+ package docker
+ 
+ import (
++	"flag"
++	"fmt"
++	info "github.com/google/cadvisor/info/v1"
++	"regexp"
+ 	"sync"
+ 	"time"
+ 
+@@ -24,22 +28,60 @@ import (
+ 	"github.com/golang/glog"
+ )
+ 
++type skippedDevices struct {
++	r *regexp.Regexp
++}
++
++var (
++	defaultSkippedDevicesRegexp = regexp.MustCompile("$^") // Regexp that matches nothing
++	skipDevicesFlag             = skippedDevices{
++		r: defaultSkippedDevicesRegexp,
++	}
++)
++
++func (self *skippedDevices) String() string {
++	return self.r.String()
++}
++
++func (self *skippedDevices) Set(value string) error {
++	r, err := regexp.Compile(value)
++
++	if err != nil {
++		return err
++	}
++
++	self.r = r
++	return nil
++}
++
++func (self *skippedDevices) Has(device string) bool {
++	return self.r.MatchString(device)
++}
++
++var skipDuFlag = flag.Bool("disk_skip_du", false, "do not use du for disk metrics (use raw FS stats instead)")
++
++func init() {
++	flag.Var(&skipDevicesFlag, "disk_skip_devices", "Regex representing devices to ignore when reporting disk metrics")
++}
++
+ type fsHandler interface {
+ 	start()
+-	usage() (uint64, uint64)
+ 	stop()
++	usage() ([]*info.FsStats, error)
++	update() error // Exposed privately for tests
+ }
+ 
+ type realFsHandler struct {
+ 	sync.RWMutex
+-	lastUpdate     time.Time
+-	usageBytes     uint64
+-	baseUsageBytes uint64
+-	period         time.Duration
+-	minPeriod      time.Duration
+-	rootfs         string
+-	extraDir       string
+-	fsInfo         fs.FsInfo
++	lastUpdate  time.Time
++	fsStats     []*info.FsStats
++	period      time.Duration
++	minPeriod   time.Duration
++	skipDu      bool
++	skipDevices skippedDevices
++	fsInfo      fs.FsInfo
++	baseDirs    map[string]struct{}
++	allDirs     map[string]struct{}
+ 	// Tells the container to stop.
+ 	stopChan chan struct{}
+ }
+@@ -50,55 +92,175 @@ const (
+ 	maxDuBackoffFactor = 20
+ )
+ 
++// Enforce that realFsHandler conforms to fsHandler interface
+ var _ fsHandler = &realFsHandler{}
+ 
+-func newFsHandler(period time.Duration, rootfs, extraDir string, fsInfo fs.FsInfo) fsHandler {
++func newFsHandler(period time.Duration, baseDirs []string, extraDirs []string, fsInfo fs.FsInfo) fsHandler {
++	allDirsSet := make(map[string]struct{})
++	baseDirsSet := make(map[string]struct{})
++
++	for _, dir := range baseDirs {
++		allDirsSet[dir] = struct{}{}
++		baseDirsSet[dir] = struct{}{}
++	}
++
++	for _, dir := range extraDirs {
++		allDirsSet[dir] = struct{}{}
++	}
++
+ 	return &realFsHandler{
+-		lastUpdate:     time.Time{},
+-		usageBytes:     0,
+-		baseUsageBytes: 0,
+-		period:         period,
+-		minPeriod:      period,
+-		rootfs:         rootfs,
+-		extraDir:       extraDir,
+-		fsInfo:         fsInfo,
+-		stopChan:       make(chan struct{}, 1),
++		lastUpdate:  time.Time{},
++		fsStats:     nil,
++		period:      period,
++		minPeriod:   period,
++		skipDu:      *skipDuFlag,
++		skipDevices: skipDevicesFlag,
++		baseDirs:    baseDirsSet,
++		allDirs:     allDirsSet,
++		fsInfo:      fsInfo,
++		stopChan:    make(chan struct{}, 1),
+ 	}
+ }
+ 
+-func (fh *realFsHandler) update() error {
+-	var (
+-		baseUsage, extraDirUsage uint64
+-		err                      error
+-	)
+-	// TODO(vishh): Add support for external mounts.
+-	if fh.rootfs != "" {
+-		baseUsage, err = fh.fsInfo.GetDirUsage(fh.rootfs, duTimeout)
++func addOrDefault(m map[string]uint64, key string, add uint64) {
++	value, ok := m[key]
++	if ok {
++		m[key] = value + add
++	} else {
++		m[key] = add
++	}
++}
++
++func (fh *realFsHandler) gatherDiskUsage(devices map[string]struct{}) (map[string]uint64, map[string]uint64, error) {
++	deviceToBaseUsageBytes := make(map[string]uint64)
++	deviceToTotalUsageBytes := make(map[string]uint64)
++
++	if fh.skipDu {
++		return deviceToBaseUsageBytes, deviceToTotalUsageBytes, nil
++	}
++
++	// Go through all directories and get their usage
++	for dir := range fh.allDirs {
++		if dir == "" {
++			// This should not happen if we're called properly, but it's
++			// presumably not worth crashing for.
++			glog.Warningf("FS handler received an empty dir: %q", dir)
++			continue
++		}
++
++		deviceInfo, err := fh.fsInfo.GetDirFsDevice(dir)
+ 		if err != nil {
+-			return err
++			return nil, nil, err
+ 		}
++
++		// Check whether this device was ignored prior to running du on it.
++		_, collectUsageForDevice := devices[deviceInfo.Device]
++		if !collectUsageForDevice {
++			continue
++		}
++
++		usage, err := fh.fsInfo.GetDirUsage(dir, duTimeout)
++		if err != nil {
++			return nil, nil, err
++		}
++
++		// Only count usage against baseUsage if this directory is a base directory
++		var baseUsage uint64 = 0
++		_, isBaseDir := fh.baseDirs[dir]
++		if isBaseDir {
++			baseUsage = usage
++		}
++
++		addOrDefault(deviceToTotalUsageBytes, deviceInfo.Device, usage)
++		addOrDefault(deviceToBaseUsageBytes, deviceInfo.Device, baseUsage)
+ 	}
+ 
+-	if fh.extraDir != "" {
+-		extraDirUsage, err = fh.fsInfo.GetDirUsage(fh.extraDir, duTimeout)
++	return deviceToBaseUsageBytes, deviceToTotalUsageBytes, nil
++}
++
++func (fh *realFsHandler) update() error {
++	// Start with figuring out which devices we care about
++	deviceSet := make(map[string]struct{})
++	for dir := range fh.allDirs {
++		fsDevice, err := fh.fsInfo.GetDirFsDevice(dir)
+ 		if err != nil {
+-			return err
++			glog.Warningf("Unable to find device for directory %q: %v", dir, err)
++			continue
++		}
++
++		if fh.skipDevices.Has(fsDevice.Device) {
++			continue
++		}
++
++		deviceSet[fsDevice.Device] = struct{}{}
++	}
++
++	// If we are relying on du for metrics, then gather the usage for each of those devices
++	deviceToBaseUsageBytes, deviceToTotalUsageBytes, err := fh.gatherDiskUsage(deviceSet)
++	if err != nil {
++		return err
++	}
++
++	// Then, grab the usage limit for each of those devices, as well as usage if we
++	// are relying on df for metrics.
++	fsStats := make([]*info.FsStats, 0)
++
++	// Request Fs info for all the device in use, but skip io stats (we won't report them,
++	// since per-container data is available via cgroups)
++	filesystems, err := fh.fsInfo.GetFsInfoForDevices(deviceSet, false)
++	if err != nil {
++		return err
++	}
++
++	for _, fs := range filesystems {
++		stat := info.FsStats{
++			Device: fs.Device,
++			Type:   string(fs.Type),
++			Limit:  fs.Capacity,
++		}
++
++		// If we're using du, then use the metrics we collected above.
++		// If we're using df, then simply use the value provided by GetGlobalFsInfo.
++		if fh.skipDu {
++			stat.Usage = fs.Capacity - fs.Available
++		} else {
++			baseUsage, ok := deviceToBaseUsageBytes[fs.Device]
++			if !ok {
++				return fmt.Errorf("Base usage for device %q expected but not collected!", fs.Device)
++			}
++
++			totalUsage, ok := deviceToTotalUsageBytes[fs.Device]
++			if !ok {
++				return fmt.Errorf("Total usage for device %q expected but not collected!", fs.Device)
++			}
++			stat.BaseUsage = baseUsage
++			stat.Usage = totalUsage
+ 		}
++
++		fsStats = append(fsStats, &stat)
++	}
++
++	if err != nil {
++		return err
+ 	}
+ 
+ 	fh.Lock()
+ 	defer fh.Unlock()
+ 	fh.lastUpdate = time.Now()
+-	fh.usageBytes = baseUsage + extraDirUsage
+-	fh.baseUsageBytes = baseUsage
++	fh.fsStats = fsStats
+ 	return nil
+ }
+ 
+ func (fh *realFsHandler) trackUsage() {
+-	fh.update()
++	err := fh.update()
++	if err != nil {
++		glog.Errorf("failed to collect filesystem stats - %v", err)
++	}
++
+ 	for {
+ 		select {
+ 		case <-fh.stopChan:
++			// TODO: Does this work without sending anything in?
+ 			return
+ 		case <-time.After(fh.period):
+ 			start := time.Now()
+@@ -113,7 +275,7 @@ func (fh *realFsHandler) trackUsage() {
+ 			}
+ 			duration := time.Since(start)
+ 			if duration > longDu {
+-				glog.V(2).Infof("`du` on following dirs took %v: %v", duration, []string{fh.rootfs, fh.extraDir})
++				glog.V(2).Infof("`du` on following dirs took %v: %v", duration, fh.allDirs)
+ 			}
+ 		}
+ 	}
+@@ -127,8 +289,12 @@ func (fh *realFsHandler) stop() {
+ 	close(fh.stopChan)
+ }
+ 
+-func (fh *realFsHandler) usage() (baseUsageBytes, totalUsageBytes uint64) {
++func (fh *realFsHandler) usage() ([]*info.FsStats, error) {
+ 	fh.RLock()
+ 	defer fh.RUnlock()
+-	return fh.baseUsageBytes, fh.usageBytes
++	if (fh.lastUpdate == time.Time{}) {
++		// Do not report metrics if we don't have any!
++		return []*info.FsStats{}, fmt.Errorf("No disk usage metrics available yet")
++	}
++	return fh.fsStats, nil
+ }
+diff --git a/container/docker/fsHandler_test.go b/container/docker/fsHandler_test.go
+new file mode 100644
+index 0000000..46307ee
+--- /dev/null
++++ b/container/docker/fsHandler_test.go
+@@ -0,0 +1,333 @@
++// Copyright 2016 Google Inc. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++package docker
++
++import (
++	"fmt"
++	"github.com/google/cadvisor/fs"
++	"github.com/stretchr/testify/assert"
++	"testing"
++	"time"
++)
++
++type testFsInfo struct {
++	allowDirUsage bool
++	t             *testing.T
++}
++
++func (self *testFsInfo) RefreshCache() {}
++
++var (
++	sda1 = fs.Fs{
++		DeviceInfo: fs.DeviceInfo{
++			Device: "/dev/sda1",
++		},
++		Type:      "ext4",
++		Capacity:  5000,
++		Available: 2000,
++	}
++	sda2 = fs.Fs{
++		DeviceInfo: fs.DeviceInfo{
++			Device: "/dev/sda2",
++		},
++		Type:      "ext4",
++		Capacity:  1000,
++		Available: 500,
++	}
++	sdb1 = fs.Fs{
++		DeviceInfo: fs.DeviceInfo{
++			Device: "/dev/sdb1",
++		},
++		Type:      "xfs",
++		Capacity:  3000,
++		Available: 500,
++	}
++	sdc1 = fs.Fs{
++		DeviceInfo: fs.DeviceInfo{
++			Device: "/dev/sdc1",
++		},
++		Type:      "zfs",
++		Capacity:  4000,
++		Available: 4000,
++	}
++)
++
++func (self *testFsInfo) GetGlobalFsInfo(_ bool) ([]fs.Fs, error) {
++	return []fs.Fs{sda1, sda2, sdb1, sdc1}, nil
++}
++
++func (self *testFsInfo) GetFsInfoForMounts(mountSet map[string]struct{}, _ bool) ([]fs.Fs, error) {
++	return nil, fmt.Errorf("Not implemented: GetFsInfoForMounts(%+v)", mountSet)
++}
++
++func (self *testFsInfo) GetFsInfoForDevices(deviceSet map[string]struct{}, _ bool) ([]fs.Fs, error) {
++	fsMap := map[string]fs.Fs{
++		"/dev/sda1": sda1,
++		"/dev/sda2": sda2,
++		"/dev/sdb1": sdb1,
++		// /dev/sdc1 isn't there because we should never be looking at it
++	}
++	fsOut := make([]fs.Fs, 0)
++
++	for device := range deviceSet {
++		fs, ok := fsMap[device]
++		if !ok {
++			return nil, fmt.Errorf("GetFsInfoForDevices was called with unexpected device: %q", device)
++		}
++		fsOut = append(fsOut, fs)
++	}
++
++	return fsOut, nil
++}
++
++func (self *testFsInfo) GetDirUsage(dir string, timeout time.Duration) (uint64, error) {
++	if !self.allowDirUsage {
++		return uint64(0), fmt.Errorf("Dir usage is disabled for this test!")
++	}
++	if dir == "/var/lib/docker/aufs/diff/aa" {
++		return uint64(100), nil
++	}
++	if dir == "/var/lib/docker/containers/aa" {
++		return uint64(50), nil
++	}
++	if dir == "/some/mount" {
++		return uint64(2000), nil
++	}
++	if dir == "/other/mount" {
++		return uint64(200), nil
++	}
++	// /sdcmount isn't there because we should never be looking at it
++	return uint64(0), fmt.Errorf("Not implemented: GetDirUsage(%s, ...)", dir)
++}
++
++func (self *testFsInfo) GetDirFsDevice(dir string) (*fs.DeviceInfo, error) {
++	if dir == "/var/lib/docker/aufs/diff/aa" {
++		return &fs.DeviceInfo{Device: "/dev/sda1"}, nil
++	}
++	if dir == "/var/lib/docker/containers/aa" {
++		return &fs.DeviceInfo{Device: "/dev/sda2"}, nil
++	}
++	if dir == "/some/mount" {
++		return &fs.DeviceInfo{Device: "/dev/sdb1"}, nil
++	}
++	if dir == "/other/mount" {
++		return &fs.DeviceInfo{Device: "/dev/sdb1"}, nil
++	}
++	if dir == "/sdcmount" {
++		return &fs.DeviceInfo{Device: "/dev/sdc1"}, nil
++	}
++	return nil, fmt.Errorf("Not implemented: GetDirFsDevice(%s)", dir)
++}
++
++func (self *testFsInfo) GetDeviceForLabel(label string) (string, error) {
++	return "", fmt.Errorf("Not implemented: GetDeviceForLabel(%s)", label)
++}
++
++func (self *testFsInfo) GetLabelsForDevice(device string) ([]string, error) {
++	return nil, fmt.Errorf("Not implemented: GetLabelsForDevice(%s)", device)
++}
++
++func (self *testFsInfo) GetMountpointForDevice(device string) (string, error) {
++	return "", fmt.Errorf("Not implemented: GetMountpointForDevice(%s)", device)
++}
++
++var testBaseDirs = []string{
++	"/var/lib/docker/aufs/diff/aa",
++	"/some/mount",
++	"/other/mount",
++}
++
++var testExtraDirs = []string{
++	"/var/lib/docker/containers/aa",
++}
++
++func TestCollectionWithDu(t *testing.T) {
++	as := assert.New(t)
++
++	(*skipDuFlag) = false
++	hdlr := newFsHandler(time.Second, testBaseDirs, testExtraDirs, &testFsInfo{
++		allowDirUsage: true,
++		t:             t,
++	})
++
++	// Usage before trackUsage should return an error
++	usage, err := hdlr.usage()
++	as.Error(err)
++	as.Equal(0, len(usage))
++
++	err = hdlr.update()
++	as.NoError(err)
++
++	usage, err = hdlr.usage()
++	as.NoError(err)
++
++	foundSda1 := false
++	foundSda2 := false
++	foundSdb1 := false
++
++	for _, stat := range usage {
++		if stat.Device == "/dev/sda1" {
++			// Only the aufs layer
++			as.Equal("ext4", stat.Type)
++			as.Equal(uint64(5000), stat.Limit)
++			as.Equal(uint64(100), stat.BaseUsage)
++			as.Equal(uint64(100), stat.Usage)
++			foundSda1 = true
++			continue
++		}
++
++		if stat.Device == "/dev/sda2" {
++			// Only logs
++			as.Equal("ext4", stat.Type)
++			as.Equal(uint64(1000), stat.Limit)
++			as.Equal(uint64(0), stat.BaseUsage)
++			as.Equal(uint64(50), stat.Usage)
++			foundSda2 = true
++			continue
++		}
++
++		if stat.Device == "/dev/sdb1" {
++			// Two mounts
++			as.Equal("xfs", stat.Type)
++			as.Equal(uint64(3000), stat.Limit)
++			as.Equal(uint64(2200), stat.BaseUsage)
++			as.Equal(uint64(2200), stat.Usage)
++			foundSdb1 = true
++			continue
++		}
++
++		t.Errorf("Unexpected device in results: %q", stat.Device)
++	}
++
++	as.True(foundSda1)
++	as.True(foundSda2)
++	as.True(foundSdb1)
++}
++
++func TestCollectionWithDf(t *testing.T) {
++	as := assert.New(t)
++
++	(*skipDuFlag) = true
++	hdlr := newFsHandler(time.Second, testBaseDirs, testExtraDirs, &testFsInfo{
++		allowDirUsage: false,
++		t:             t,
++	})
++
++	err := hdlr.update()
++	as.NoError(err)
++
++	usage, err := hdlr.usage()
++	as.NoError(err)
++
++	foundSda1 := false
++	foundSda2 := false
++	foundSdb1 := false
++
++	for _, stat := range usage {
++		if stat.Device == "/dev/sda1" {
++			// Only the aufs layer
++			as.Equal(uint64(5000), stat.Limit)
++			as.Equal(uint64(3000), stat.Usage)
++			foundSda1 = true
++			continue
++		}
++
++		if stat.Device == "/dev/sda2" {
++			// Only logs
++			as.Equal(uint64(1000), stat.Limit)
++			as.Equal(uint64(500), stat.Usage)
++			foundSda2 = true
++			continue
++		}
++
++		if stat.Device == "/dev/sdb1" {
++			// Two mounts
++			as.Equal(uint64(3000), stat.Limit)
++			as.Equal(uint64(2500), stat.Usage)
++			foundSdb1 = true
++			continue
++		}
++
++		t.Errorf("Unexpected device in results: %q", stat.Device)
++	}
++
++	as.True(foundSda1)
++	as.True(foundSda2)
++	as.True(foundSdb1)
++}
++
++func TestCollectionWithDfAndIgnoredDevices(t *testing.T) {
++	as := assert.New(t)
++
++	(*skipDuFlag) = true
++	skipDevicesFlag.Set("/dev/sda\\d")
++	hdlr := newFsHandler(time.Second, testBaseDirs, testExtraDirs, &testFsInfo{
++		allowDirUsage: false,
++		t:             t,
++	})
++
++	err := hdlr.update()
++	as.NoError(err)
++
++	usage, err := hdlr.usage()
++	as.NoError(err)
++
++	foundSdb1 := false
++
++	for _, stat := range usage {
++		if stat.Device == "/dev/sda1" {
++			t.Errorf("Metrics for /dev/sda1 reported despite being ignored!")
++			continue
++		}
++
++		if stat.Device == "/dev/sda2" {
++			t.Errorf("Metrics for /dev/sda2 reported despite being ignored!")
++			continue
++		}
++
++		if stat.Device == "/dev/sdb1" {
++			foundSdb1 = true
++			continue
++		}
++
++		t.Errorf("Unexpected device in results: %q", stat.Device)
++	}
++
++	as.True(foundSdb1)
++}
++
++func TestCollectionWithDuAndIgnoredDevices(t *testing.T) {
++	as := assert.New(t)
++
++	(*skipDuFlag) = false
++	skipDevicesFlag.Set("/dev/sdc1")
++	hdlr := newFsHandler(time.Second, []string{"/sdcmount"}, []string{}, &testFsInfo{
++		allowDirUsage: true,
++		t:             t,
++	})
++
++	err := hdlr.update()
++	as.NoError(err)
++
++	usage, err := hdlr.usage()
++	as.NoError(err)
++
++	for _, stat := range usage {
++		if stat.Device == "/dev/sdc1" {
++			t.Errorf("Metrics for /dev/sdc1 reported despite being ignored!")
++			continue
++		}
++	}
++}
+diff --git a/container/docker/handler.go b/container/docker/handler.go
+index bfdbeb2..38285bf 100644
+--- a/container/docker/handler.go
++++ b/container/docker/handler.go
+@@ -30,6 +30,7 @@ import (
+ 	"github.com/google/cadvisor/utils"
+ 
+ 	docker "github.com/fsouza/go-dockerclient"
++	"github.com/golang/glog"
+ 	"github.com/opencontainers/runc/libcontainer/cgroups"
+ 	cgroupfs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
+ 	libcontainerconfigs "github.com/opencontainers/runc/libcontainer/configs"
+@@ -39,7 +40,7 @@ const (
+ 	// The read write layers exist here.
+ 	aufsRWLayer = "diff"
+ 	// Path to the directory where docker stores log files if the json logging driver is enabled.
+-	pathToContainersDir = "containers"
++	pathToContainersLogDir = "containers"
+ )
+ 
+ type dockerContainerHandler struct {
+@@ -56,9 +57,8 @@ type dockerContainerHandler struct {
+ 	// Manager of this container's cgroups.
+ 	cgroupManager cgroups.Manager
+ 
+-	storageDriver    storageDriver
+-	fsInfo           fs.FsInfo
+-	rootfsStorageDir string
++	storageDriver storageDriver
++	fsInfo        fs.FsInfo
+ 
+ 	// Time at which this container was created.
+ 	creationTime time.Time
+@@ -67,6 +67,10 @@ type dockerContainerHandler struct {
+ 	labels map[string]string
+ 	envs   map[string]string
+ 
++	// The directories in use by this container
++	baseDirs  []string
++	extraDirs []string
++
+ 	// The container PID used to switch namespaces as required
+ 	pid int
+ 
+@@ -137,21 +141,10 @@ func newDockerContainerHandler(
+ 
+ 	id := ContainerNameToDockerId(name)
+ 
+-	// Add the Containers dir where the log files are stored.
+-	// FIXME: Give `otherStorageDir` a more descriptive name.
+-	otherStorageDir := path.Join(storageDir, pathToContainersDir, id)
+-
+ 	rwLayerID, err := getRwLayerID(id, storageDir, storageDriver, dockerVersion)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	var rootfsStorageDir string
+-	switch storageDriver {
+-	case aufsStorageDriver:
+-		rootfsStorageDir = path.Join(storageDir, string(aufsStorageDriver), aufsRWLayer, rwLayerID)
+-	case overlayStorageDriver:
+-		rootfsStorageDir = path.Join(storageDir, string(overlayStorageDriver), rwLayerID)
+-	}
+ 
+ 	handler := &dockerContainerHandler{
+ 		id:                 id,
+@@ -163,15 +156,10 @@ func newDockerContainerHandler(
+ 		storageDriver:      storageDriver,
+ 		fsInfo:             fsInfo,
+ 		rootFs:             rootFs,
+-		rootfsStorageDir:   rootfsStorageDir,
+ 		envs:               make(map[string]string),
+ 		ignoreMetrics:      ignoreMetrics,
+ 	}
+ 
+-	if !ignoreMetrics.Has(container.DiskUsageMetrics) {
+-		handler.fsHandler = newFsHandler(time.Minute, rootfsStorageDir, otherStorageDir, fsInfo)
+-	}
+-
+ 	// We assume that if Inspect fails then the container is not known to docker.
+ 	ctnr, err := client.InspectContainer(id)
+ 	if err != nil {
+@@ -196,6 +184,47 @@ func newDockerContainerHandler(
+ 		}
+ 	}
+ 
++	handler.baseDirs = make([]string, 0)
++	handler.extraDirs = make([]string, 0)
++
++	// Docker API >= 1.20 exposes a "Mounts" list of structures representing mounts
++	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.20/)
++	for _, mount := range ctnr.Mounts {
++		handler.baseDirs = append(handler.baseDirs, path.Join(rootFs, mount.Source))
++	}
++
++	// Docker API < 1.20 exposes a "Volumes" mapping of container paths to host paths.
++	// (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.19/)
++	for _, hostPath := range ctnr.Volumes {
++		handler.baseDirs = append(handler.baseDirs, path.Join(rootFs, hostPath))
++	}
++
++	// Now, handle the rootfs
++	rootfsStorageDir := ""
++	switch storageDriver {
++	case aufsStorageDriver:
++		rootfsStorageDir = path.Join(storageDir, string(aufsStorageDriver), aufsRWLayer, rwLayerID)
++	case overlayStorageDriver:
++		rootfsStorageDir = path.Join(storageDir, string(overlayStorageDriver), rwLayerID)
++	}
++
++	// We support (and found) the mount
++	if rootfsStorageDir != "" {
++		handler.baseDirs = append(handler.baseDirs, rootfsStorageDir)
++	} else {
++		glog.Warningf("Unable to find root mount for container %q (storageDriver: %q)", name, storageDriver)
++	}
++
++	// Now, handle the storage dir
++	logsStorageDir := path.Join(storageDir, pathToContainersLogDir, id)
++	handler.extraDirs = append(handler.extraDirs, logsStorageDir)
++
++	// And start DiskUsageMetrics (if enabled)
++	if !ignoreMetrics.Has(container.DiskUsageMetrics) {
++		// We need to find all our base dirs!
++		handler.fsHandler = newFsHandler(time.Minute, handler.baseDirs, handler.extraDirs, fsInfo)
++	}
++
+ 	return handler, nil
+ }
+ 
+@@ -287,10 +316,7 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
+ 	spec.CreationTime = self.creationTime
+ 
+ 	if !self.ignoreMetrics.Has(container.DiskUsageMetrics) {
+-		switch self.storageDriver {
+-		case aufsStorageDriver, overlayStorageDriver, zfsStorageDriver:
+-			spec.HasFilesystem = true
+-		}
++		spec.HasFilesystem = true
+ 	}
+ 
+ 	spec.Labels = self.labels
+@@ -302,43 +328,19 @@ func (self *dockerContainerHandler) GetSpec() (info.ContainerSpec, error) {
+ }
+ 
+ func (self *dockerContainerHandler) getFsStats(stats *info.ContainerStats) error {
+-	if self.ignoreMetrics.Has(container.DiskUsageMetrics) {
+-		return nil
+-	}
+-	switch self.storageDriver {
+-	case aufsStorageDriver, overlayStorageDriver, zfsStorageDriver:
+-	default:
++	if self.fsHandler == nil {
+ 		return nil
+ 	}
++	fsStats, err := self.fsHandler.usage()
+ 
+-	deviceInfo, err := self.fsInfo.GetDirFsDevice(self.rootfsStorageDir)
+-	if err != nil {
+-		return err
+-	}
+-
+-	mi, err := self.machineInfoFactory.GetMachineInfo()
+ 	if err != nil {
+ 		return err
+ 	}
+-	var (
+-		limit  uint64
+-		fsType string
+-	)
+ 
+-	// Docker does not impose any filesystem limits for containers. So use capacity as limit.
+-	for _, fs := range mi.Filesystems {
+-		if fs.Device == deviceInfo.Device {
+-			limit = fs.Capacity
+-			fsType = fs.Type
+-			break
+-		}
++	for _, stat := range fsStats {
++		stats.Filesystem = append(stats.Filesystem, *stat)
+ 	}
+ 
+-	fsStat := info.FsStats{Device: deviceInfo.Device, Type: fsType, Limit: limit}
+-
+-	fsStat.BaseUsage, fsStat.Usage = self.fsHandler.usage()
+-	stats.Filesystem = append(stats.Filesystem, fsStat)
+-
+ 	return nil
+ }
+ 
+diff --git a/container/raw/handler.go b/container/raw/handler.go
+index 94d3141..6de749a 100644
+--- a/container/raw/handler.go
++++ b/container/raw/handler.go
+@@ -291,7 +291,7 @@ func (self *rawContainerHandler) GetSpec() (info.ContainerSpec, error) {
+ func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
+ 	// Get Filesystem information only for the root cgroup.
+ 	if isRootCgroup(self.name) {
+-		filesystems, err := self.fsInfo.GetGlobalFsInfo()
++		filesystems, err := self.fsInfo.GetGlobalFsInfo(true)
+ 		if err != nil {
+ 			return err
+ 		}
+@@ -323,7 +323,7 @@ func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
+ 		for _, mount := range self.externalMounts {
+ 			mountSet[mount.HostDir] = struct{}{}
+ 		}
+-		filesystems, err := self.fsInfo.GetFsInfoForPath(mountSet)
++		filesystems, err := self.fsInfo.GetFsInfoForMounts(mountSet, true)
+ 		if err != nil {
+ 			return err
+ 		}
+diff --git a/fs/fs.go b/fs/fs.go
+index 458d8c4..3e05a99 100644
+--- a/fs/fs.go
++++ b/fs/fs.go
+@@ -83,52 +83,88 @@ func (self *RealFsInfo) GetMountpointForDevice(dev string) (string, error) {
+ 	return p.mountpoint, nil
+ }
+ 
+-func (self *RealFsInfo) GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, error) {
+-	filesystems := make([]Fs, 0)
+-	deviceSet := make(map[string]struct{})
+-	diskStatsMap, err := getDiskStatsMap("/proc/diskstats")
++func (self *RealFsInfo) getFilteredFsInfo(filter func(device string, partition partition) bool, withIoStats bool) ([]Fs, error) {
++	filesystemsOut := make([]Fs, 0)
++
++	err := self.partitionCache.ApplyOverPartitions(func(device string, partition partition) error {
++		if !filter(device, partition) {
++			return nil
++		}
++
++		var (
++			err error
++			fs  Fs
++		)
++
++		switch partition.fsType {
++		case DeviceMapper.String():
++			fs.Capacity, fs.Free, fs.Available, err = getDMStats(device, partition.blockSize)
++			fs.Type = DeviceMapper
++		case ZFS.String():
++			fs.Capacity, fs.Free, fs.Available, err = getZfstats(device)
++			fs.Type = ZFS
++		default:
++			fs.Capacity, fs.Free, fs.Available, fs.Inodes, fs.InodesFree, err = getVfsStats(partition.mountpoint)
++			fs.Type = VFS
++		}
++
++		if err != nil {
++			// Only log, don't throw an error
++			glog.Errorf("Stat fs for %q failed. Error: %v", device, err)
++			return nil
++		}
++
++		fs.DeviceInfo = DeviceInfo{
++			Device: device,
++			Major:  uint(partition.major),
++			Minor:  uint(partition.minor),
++		}
++
++		filesystemsOut = append(filesystemsOut, fs)
++		return nil
++	})
++
+ 	if err != nil {
+ 		return nil, err
+ 	}
+ 
+-	self.partitionCache.ApplyOverPartitions(func(device string, partition partition) error {
+-		_, hasMount := mountSet[partition.mountpoint]
+-		_, hasDevice := deviceSet[device]
+-		if mountSet == nil || (hasMount && !hasDevice) {
+-			var (
+-				err error
+-				fs  Fs
+-			)
+-			switch partition.fsType {
+-			case DeviceMapper.String():
+-				fs.Capacity, fs.Free, fs.Available, err = getDMStats(device, partition.blockSize)
+-				fs.Type = DeviceMapper
+-			case ZFS.String():
+-				fs.Capacity, fs.Free, fs.Available, err = getZfstats(device)
+-				fs.Type = ZFS
+-			default:
+-				fs.Capacity, fs.Free, fs.Available, fs.Inodes, fs.InodesFree, err = getVfsStats(partition.mountpoint)
+-				fs.Type = VFS
+-			}
++	if withIoStats {
++		diskStatsMap, err := getDiskStatsMap("/proc/diskstats")
++		if err != nil {
++			return nil, err
++		}
+ 
+-			if err != nil {
+-				glog.Errorf("Stat fs failed. Error: %v", err)
+-			} else {
+-				deviceSet[device] = struct{}{}
+-				fs.DeviceInfo = DeviceInfo{
+-					Device: device,
+-					Major:  uint(partition.major),
+-					Minor:  uint(partition.minor),
+-				}
+-				fs.DiskStats = diskStatsMap[device]
+-				filesystems = append(filesystems, fs)
++		for _, fs := range filesystemsOut {
++			diskStats, ok := diskStatsMap[fs.DeviceInfo.Device]
++			if !ok {
++				glog.Errorf("Disk stats for %q not found", fs.DeviceInfo.Device)
++				continue
+ 			}
++			fs.DiskStats = diskStats
+ 		}
++	}
+ 
+-		return nil
+-	})
++	return filesystemsOut, nil
++}
++
++func (self *RealFsInfo) GetFsInfoForMounts(mountSet map[string]struct{}, withIoStats bool) ([]Fs, error) {
++	return self.getFilteredFsInfo(func(_ string, partition partition) bool {
++		_, hasMount := mountSet[partition.mountpoint]
++		return hasMount
++	}, withIoStats)
++}
+ 
+-	return filesystems, nil
++func (self *RealFsInfo) GetFsInfoForDevices(deviceSet map[string]struct{}, withIoStats bool) ([]Fs, error) {
++	return self.getFilteredFsInfo(func(device string, _ partition) bool {
++		_, hasDevice := deviceSet[device]
++		return hasDevice
++	}, withIoStats)
++}
++
++func (self *RealFsInfo) GetGlobalFsInfo(withIoStats bool) ([]Fs, error) {
++	return self.getFilteredFsInfo(func(_ string, _ partition) bool {
++		return true
++	}, withIoStats)
+ }
+ 
+ var partitionRegex = regexp.MustCompile(`^(?:(?:s|xv)d[a-z]+\d*|dm-\d+)$`)
+@@ -186,10 +222,6 @@ func getDiskStatsMap(diskStatsFile string) (map[string]DiskStats, error) {
+ 	return diskStatsMap, nil
+ }
+ 
+-func (self *RealFsInfo) GetGlobalFsInfo() ([]Fs, error) {
+-	return self.GetFsInfoForPath(nil)
+-}
+-
+ func major(devNumber uint64) uint {
+ 	return uint((devNumber >> 8) & 0xfff)
+ }
+diff --git a/fs/types.go b/fs/types.go
+index 17bc5f1..b345339 100644
+--- a/fs/types.go
++++ b/fs/types.go
+@@ -72,10 +72,13 @@ type FsInfo interface {
+ 	RefreshCache()
+ 
+ 	// Returns capacity and free space, in bytes, of all the ext2, ext3, ext4 filesystems on the host.
+-	GetGlobalFsInfo() ([]Fs, error)
++	GetGlobalFsInfo(withIoStats bool) ([]Fs, error)
+ 
+ 	// Returns capacity and free space, in bytes, of the set of mounts passed.
+-	GetFsInfoForPath(mountSet map[string]struct{}) ([]Fs, error)
++	GetFsInfoForMounts(mountSet map[string]struct{}, withIoStats bool) ([]Fs, error)
++
++	// Returns capacity and free space, in bytes, of the set of devices passed.
++	GetFsInfoForDevices(deviceSet map[string]struct{}, withIoStats bool) ([]Fs, error)
+ 
+ 	// Returns number of bytes occupied by 'dir'.
+ 	GetDirUsage(dir string, timeout time.Duration) (uint64, error)
+diff --git a/manager/machine.go b/manager/machine.go
+index d459815..5dd362c 100644
+--- a/manager/machine.go
++++ b/manager/machine.go
+@@ -68,7 +68,7 @@ func getMachineInfo(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (
+ 		return nil, err
+ 	}
+ 
+-	filesystems, err := fsInfo.GetGlobalFsInfo()
++	filesystems, err := fsInfo.GetGlobalFsInfo(false)
+ 	if err != nil {
+ 		glog.Errorf("Failed to get global filesystem information: %v", err)
+ 	}
+-- 
+2.7.4
+

--- a/patches/0017-Support-ecryptfs-volumes.patch
+++ b/patches/0017-Support-ecryptfs-volumes.patch
@@ -1,0 +1,30 @@
+From 439423b32a53201eeb573c6b92d3eff0a316ac0b Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Mon, 11 Apr 2016 18:33:13 +0200
+Subject: [PATCH] Support ecryptfs volumes
+
+---
+ fs/partition_cache.go | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/fs/partition_cache.go b/fs/partition_cache.go
+index 45248e1..d1b3a83 100644
+--- a/fs/partition_cache.go
++++ b/fs/partition_cache.go
+@@ -75,9 +75,10 @@ func (self *RealPartitionCache) Refresh() error {
+ 
+ 	supportedFsType := map[string]bool{
+ 		// all ext systems are checked through prefix.
+-		"btrfs": true,
+-		"xfs":   true,
+-		"zfs":   true,
++		"btrfs":    true,
++		"xfs":      true,
++		"zfs":      true,
++		"ecryptfs": true,
+ 	}
+ 
+ 	mounts, err := self.mountInfo.GetMounts()
+-- 
+2.7.4
+

--- a/patches/0018-Deference-symlinks-when-loading-partition-list.patch
+++ b/patches/0018-Deference-symlinks-when-loading-partition-list.patch
@@ -1,0 +1,85 @@
+From 849b6fc4cc2cb96f40798e27a50b5a405c87dbd1 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 12 Apr 2016 14:29:24 +0200
+Subject: [PATCH] Deference symlinks when loading partition list
+
+---
+ fs/fs.go              |  8 +++-----
+ fs/mount_helper.go    | 18 +++++++++++++++++-
+ fs/partition_cache.go |  2 +-
+ 3 files changed, 21 insertions(+), 7 deletions(-)
+
+diff --git a/fs/fs.go b/fs/fs.go
+index 3e05a99..a7dd4c8 100644
+--- a/fs/fs.go
++++ b/fs/fs.go
+@@ -49,14 +49,12 @@ func NewFsInfo(context Context) (FsInfo, error) {
+ 		partitionCache: NewPartitionCache(context),
+ 	}
+ 
+-	partitions := make([]partition, 0)
+-	fsInfo.partitionCache.ApplyOverPartitions(func(_ string, p partition) error {
+-		partitions = append(partitions, p)
++	glog.Infof("Listing filesystem partitions:")
++	fsInfo.partitionCache.ApplyOverPartitions(func(d string, p partition) error {
++		glog.Infof("%s: %+v", d, p)
+ 		return nil
+ 	})
+ 
+-	glog.Infof("Filesystem partitions: %+v", partitions)
+-
+ 	return fsInfo, nil
+ }
+ 
+diff --git a/fs/mount_helper.go b/fs/mount_helper.go
+index b1ca52f..737d019 100644
+--- a/fs/mount_helper.go
++++ b/fs/mount_helper.go
+@@ -17,6 +17,7 @@ package fs
+ 
+ import (
+ 	dockerMountInfo "github.com/docker/docker/pkg/mount"
++	"path/filepath"
+ )
+ 
+ type mountInfoClient interface {
+@@ -26,7 +27,22 @@ type mountInfoClient interface {
+ type defaultMountInfoClient struct{}
+ 
+ func (*defaultMountInfoClient) GetMounts() ([]*dockerMountInfo.Info, error) {
+-	return dockerMountInfo.GetMounts()
++	mounts, err := dockerMountInfo.GetMounts()
++	if err != nil {
++		return nil, err
++	}
++
++	for _, mount := range mounts {
++		// Dereference the device name to account for symlinks (e.g. /dev/disk/by-uuid/...)
++		// Not all mounts can be de-referenced though, so we skip silently mounts that cannot.
++		deviceName, err := filepath.EvalSymlinks(mount.Source)
++		if err != nil {
++			continue
++		}
++		mount.Source = deviceName
++	}
++
++	return mounts, nil
+ }
+ 
+ var _ mountInfoClient = &defaultMountInfoClient{}
+diff --git a/fs/partition_cache.go b/fs/partition_cache.go
+index d1b3a83..c3b14e2 100644
+--- a/fs/partition_cache.go
++++ b/fs/partition_cache.go
+@@ -95,7 +95,7 @@ func (self *RealPartitionCache) Refresh() error {
+ 			continue
+ 		}
+ 		if mount.Fstype == "zfs" {
+-			Fstype = mount.Fstype // REVIEW: Is this correct?
++			Fstype = mount.Fstype // REVIEW: Is this correct? We don't set Fstype for non-ZFS.
+ 		}
+ 		partitions[mount.Source] = partition{
+ 			fsType:     Fstype,
+-- 
+2.7.4
+

--- a/patches/0019-Silence-disk-stat-warnings.patch
+++ b/patches/0019-Silence-disk-stat-warnings.patch
@@ -1,0 +1,35 @@
+From f69b933965d45e27362a9934a9d87ce49bcbbb2b Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 12 Apr 2016 14:42:09 +0200
+Subject: [PATCH] Silence disk stat warnings
+
+Adding this warning was useful to find the need to de-reference mount
+sources, but now it's mainly creating noise considering our ecryptfs
+volumes don't show up in diskstats.
+
+In practice, we're not really using those stats for much, so it's fine
+if they are missing.
+---
+ fs/fs.go | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/fs/fs.go b/fs/fs.go
+index a7dd4c8..d9dbefe 100644
+--- a/fs/fs.go
++++ b/fs/fs.go
+@@ -135,7 +135,11 @@ func (self *RealFsInfo) getFilteredFsInfo(filter func(device string, partition p
+ 		for _, fs := range filesystemsOut {
+ 			diskStats, ok := diskStatsMap[fs.DeviceInfo.Device]
+ 			if !ok {
+-				glog.Errorf("Disk stats for %q not found", fs.DeviceInfo.Device)
++				// TODO: ecryptfs breaks with this, since the disk stats we should
++				// report are the disk stats for the underlying physical volume, not
++				// the ecryptfs one. We should (probably) handle ecryptfs a little
++				// differently here, and look at the disk stats for the lower layer.
++				// glog.Warningf("Disk stats for %q not found", fs.DeviceInfo.Device)
+ 				continue
+ 			}
+ 			fs.DiskStats = diskStats
+-- 
+2.7.4
+

--- a/patches/0020-Make-panic-timeout-configurable.patch
+++ b/patches/0020-Make-panic-timeout-configurable.patch
@@ -1,0 +1,50 @@
+From 4294dd05b9addb1dc44902947f1d3c997ed332a0 Mon Sep 17 00:00:00 2001
+From: Thomas Orozco <thomas@orozco.fr>
+Date: Tue, 12 Apr 2016 18:55:44 +0200
+Subject: [PATCH] Make panic timeout configurable
+
+---
+ manager/container.go | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/manager/container.go b/manager/container.go
+index 9ee2b53..1a4d7f3 100644
+--- a/manager/container.go
++++ b/manager/container.go
+@@ -44,11 +44,14 @@ import (
+ )
+ 
+ // Housekeeping interval.
+-var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
+ var HousekeepingInterval = flag.Duration("housekeeping_interval", 1*time.Second, "Interval between container housekeepings")
++
++var enableLoadReader = flag.Bool("enable_load_reader", false, "Whether to enable cpu load reader")
+ var LoadreaderInterval = flag.Duration("load_reader_interval", 1*time.Second, "Interval between load reader probes")
+ var MaxLoadReaderInterval = flag.Duration("max_load_reader_interval", 60*time.Second, "Interval between load reader probes")
+ 
++var PanicTimeout = flag.Duration("panic_timeout", 1*time.Minute, "Delay after which cAdvisor should panic if housekeeping or LA probe hasn't completed")
++
+ var cgroupPathRegExp = regexp.MustCompile(`devices[^:]*:(.*?)[,;$]`)
+ 
+ type containerInfo struct {
+@@ -435,7 +438,7 @@ func (c *containerData) doHousekeepingLoop() {
+ 		default:
+ 			// Perform housekeeping.
+ 			start := time.Now()
+-			c.doWithTimeout((*containerData).updateStats, (*HousekeepingInterval)*2)
++			c.doWithTimeout((*containerData).updateStats, *PanicTimeout)
+ 
+ 			// Log if housekeeping took too long.
+ 			duration := time.Since(start)
+@@ -610,7 +613,7 @@ func (c *containerData) doLoadReaderLoop() {
+ 		case <-c.loadStop:
+ 			return
+ 		default:
+-			c.doWithTimeout((*containerData).doLoadReaderIteration, (*LoadreaderInterval)*2)
++			c.doWithTimeout((*containerData).doLoadReaderIteration, *PanicTimeout)
+ 		}
+ 
+ 		// Schedule the next housekeeping. Sleep until that time.
+-- 
+2.7.4
+


### PR DESCRIPTION
This includes 5 patchset updates (including what's already in #9). Specifically:

- Probe for LA independently of the housekeeping interval, which as described in #9 ensures we get  more smoother data for load average 
- Report IO stats (aggregated for all devices) to InfluxDB.
- Exit when the Docker factory can't be initialized (e.g. because Docker was stopped).
- Track the volumes mounted in containers, and expose a flag to use FS metrics (instead of DU) to report on their usage. Also expose a flag to ignore volumes (which allows us to skip reporting usage for e.g. `/var/lib/docker`). 

I've also added a bunch of tests (specifically for the last change, since it's by far the most substantial).

cc @fancyremarker 